### PR TITLE
Bind string literal

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -732,6 +732,7 @@ pub fn Statement(comptime opts: StatementOptions, comptime query: ParsedQuery) t
                     .Float, .ComptimeFloat => _ = c.sqlite3_bind_double(self.stmt, column, field),
                     .Bool => _ = c.sqlite3_bind_int64(self.stmt, column, @boolToInt(field)),
                     .Pointer => |ptr| switch (ptr.size) {
+                        .One => self.bindField(ptr.child, field_name, i, field.*),
                         else => @compileError("cannot bind field " ++ field_name ++ " of type " ++ @typeName(FieldType)),
                     },
                     .Array => |arr| {

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1289,6 +1289,26 @@ test "sqlite: insert bool and bind bool" {
     testing.expect(b.?);
 }
 
+test "sqlite: bind string literal" {
+    var db: Db = undefined;
+    try db.init(initOptions());
+    try addTestData(&db);
+
+    try db.exec("INSERT INTO article(id, data) VALUES(?, ?)", .{
+        @as(usize, 10),
+        "foobar",
+    });
+
+    const query = "SELECT id FROM article WHERE data = ?";
+
+    var stmt = try db.prepare(query);
+    defer stmt.deinit();
+
+    const b = try stmt.one(usize, .{}, .{"foobar"});
+    testing.expect(b != null);
+    testing.expectEqual(@as(usize, 10), b.?);
+}
+
 test "sqlite: statement reset" {
     var db: Db = undefined;
     try db.init(initOptions());


### PR DESCRIPTION
Allow binding pointers which gives us two things:
* we can bind string literals which are technically pointers to arrays
* we can handle `[]const u8` and `[]u8` in the `.Pointer` switch arm

Fixes #13 
