### PR TITLE
Rework test runner script

### DIFF
--- a/.builds/alpine-edge-amd64.yml
+++ b/.builds/alpine-edge-amd64.yml
@@ -25,11 +25,3 @@ tasks:
   - test_filesystem: |
       cd zig-sqlite
       TERM=dumb zig build test -Din_memory=false
-
-  - test_in_memory_with_bundled_library: |
-      cd zig-sqlite
-      TERM=dumb zig build test -Din_memory=true -Duse_bundled
-
-  - test_filesystem_with_bundled_library: |
-      cd zig-sqlite
-      TERM=dumb zig build test -Din_memory=false -Duse_bundled

--- a/.builds/debian-stable-amd64.yml
+++ b/.builds/debian-stable-amd64.yml
@@ -24,7 +24,3 @@ tasks:
   - test_filesystem: |
       cd zig-sqlite
       TERM=dumb zig build test -Din_memory=false
-
-  - test_with_bundled_library: |
-      cd zig-sqlite
-      TERM=dumb zig build test -Din_memory -Duse_bundled

--- a/.builds/freebsd-latest-amd64.yml
+++ b/.builds/freebsd-latest-amd64.yml
@@ -24,11 +24,3 @@ tasks:
   - test_filesystem: |
       cd zig-sqlite
       TERM=dumb zig build test -Din_memory=false
-
-  - test_in_memory_with_bundled_library: |
-      cd zig-sqlite
-      TERM=dumb zig build test -Din_memory=true -Duse_bundled
-
-  - test_filesystem_with_bundled_library: |
-      cd zig-sqlite
-      TERM=dumb zig build test -Din_memory=false -Duse_bundled

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Run Tests in memory
         run: zig build test -Din_memory=true
 
-      - name: Run Tests in memory using the bundled SQLite
-        run: zig build test -Din_memory=true -Duse_bundled
-
   test-with-filesystem:
     strategy:
       matrix:
@@ -57,6 +54,3 @@ jobs:
 
       - name: Run Tests with filesystem
         run: zig build test -Din_memory=false
-
-      - name: Run Tests with filesystem using the bundled SQLite
-        run: zig build test -Din_memory=false -Duse_bundled

--- a/build.zig
+++ b/build.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const std = @import("std");
 
 var sqlite3: ?*std.build.LibExeObjStep = null;
@@ -37,40 +38,161 @@ fn getTarget(original_target: std.zig.CrossTarget, bundled: bool) std.zig.CrossT
     return original_target;
 }
 
+const TestTarget = struct {
+    target: std.zig.CrossTarget = @as(std.zig.CrossTarget, .{}),
+    mode: builtin.Mode = .Debug,
+    single_threaded: bool = false,
+    bundled: bool,
+};
+
+const all_test_targets = switch (std.Target.current.cpu.arch) {
+    .x86_64 => switch (std.Target.current.os.tag) {
+        .linux => [_]TestTarget{
+            TestTarget{
+                .target = .{},
+                .bundled = false,
+            },
+            TestTarget{
+                .target = .{
+                    .cpu_arch = .x86_64,
+                    .abi = .musl,
+                },
+                .bundled = true,
+            },
+            TestTarget{
+                .target = .{
+                    .cpu_arch = .i386,
+                    .abi = .musl,
+                },
+                .bundled = true,
+            },
+            TestTarget{
+                .target = .{
+                    .cpu_arch = .aarch64,
+                    .abi = .musl,
+                },
+                .bundled = true,
+            },
+            TestTarget{
+                .target = .{
+                    .cpu_arch = .riscv64,
+                    .abi = .musl,
+                },
+                .bundled = true,
+            },
+            TestTarget{
+                .target = .{
+                    .cpu_arch = .mips,
+                    .abi = .musl,
+                },
+                .bundled = true,
+            },
+            TestTarget{
+                .target = .{
+                    .cpu_arch = .arm,
+                    .abi = .musleabihf,
+                },
+                .bundled = true,
+            },
+        },
+        .windows => [_]TestTarget{
+            TestTarget{
+                .target = .{},
+                .bundled = false,
+            },
+            TestTarget{
+                .target = .{
+                    .cpu_arch = .x86_64,
+                },
+                .bundled = true,
+            },
+            TestTarget{
+                .target = .{
+                    .cpu_arch = .i386,
+                },
+                .bundled = true,
+            },
+        },
+        .freebsd => [_]TestTarget{
+            TestTarget{
+                .target = .{},
+                .bundled = false,
+            },
+            TestTarget{
+                .target = .{
+                    .cpu_arch = .x86_64,
+                },
+                .bundled = true,
+            },
+        },
+        else => [_]TestTarget{
+            TestTarget{
+                .target = .{},
+                .bundled = false,
+            },
+        },
+    },
+    else => [_]TestTarget{
+        TestTarget{
+            .target = .{},
+            .bundled = false,
+        },
+    },
+};
+
 pub fn build(b: *std.build.Builder) void {
     const in_memory = b.option(bool, "in_memory", "Should the tests run with sqlite in memory (default true)") orelse true;
     const dbfile = b.option([]const u8, "dbfile", "Always use this database file instead of a temporary one");
     const use_bundled = b.option(bool, "use_bundled", "Use the bundled sqlite3 source instead of linking the system library (default false)") orelse false;
+    const enable_qemu = b.option(bool, "enable_qemu", "Enable qemu for running tests (default false)") orelse false;
 
-    const target = getTarget(b.standardTargetOptions(.{}), use_bundled);
-    const mode = b.standardReleaseOptions();
+    const target = b.standardTargetOptions(.{});
 
-    // Build sqlite from source if asked
-    if (use_bundled) {
-        const lib = b.addStaticLibrary("sqlite", null);
-        lib.addCSourceFile("c/sqlite3.c", &[_][]const u8{"-std=c99"});
-        lib.linkLibC();
-        lib.setTarget(target);
-        lib.setBuildMode(mode);
-        sqlite3 = lib;
-    }
-
-    const lib = b.addStaticLibrary("zig-sqlite", "sqlite.zig");
-    lib.addIncludeDir("c");
-    linkSqlite(lib);
-    lib.setTarget(target);
-    lib.setBuildMode(mode);
-    lib.install();
-
-    var main_tests = b.addTest("sqlite.zig");
-    main_tests.addIncludeDir("c");
-    linkSqlite(main_tests);
-    main_tests.setBuildMode(mode);
-    main_tests.setTarget(target);
-    main_tests.setBuildMode(mode);
-    main_tests.addBuildOption(bool, "in_memory", in_memory);
-    main_tests.addBuildOption(?[]const u8, "dbfile", dbfile);
+    const test_targets = if (target.isNative())
+        &all_test_targets
+    else
+        &[_]TestTarget{.{
+            .target = target,
+            .bundled = use_bundled,
+        }};
 
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+    for (test_targets) |test_target| {
+        const cross_target = getTarget(test_target.target, test_target.bundled);
+
+        const tests = b.addTest("sqlite.zig");
+
+        if (test_target.bundled) {
+            const lib = b.addStaticLibrary("sqlite", null);
+            lib.addCSourceFile("c/sqlite3.c", &[_][]const u8{"-std=c99"});
+            lib.linkLibC();
+            lib.setTarget(cross_target);
+            lib.setBuildMode(test_target.mode);
+            sqlite3 = lib;
+        }
+
+        const lib = b.addStaticLibrary("zig-sqlite", "sqlite.zig");
+        lib.addIncludeDir("c");
+        linkSqlite(lib);
+        lib.setTarget(cross_target);
+        lib.setBuildMode(test_target.mode);
+
+        const single_threaded_txt = if (test_target.single_threaded) "single" else "multi";
+        tests.setNamePrefix(b.fmt("{s}-{s}-{s} ", .{
+            cross_target.zigTriple(b.allocator),
+            @tagName(test_target.mode),
+            single_threaded_txt,
+        }));
+        tests.single_threaded = test_target.single_threaded;
+        tests.setBuildMode(test_target.mode);
+        tests.setTarget(cross_target);
+        tests.addIncludeDir("c");
+        linkSqlite(tests);
+        tests.enable_qemu = enable_qemu;
+
+        tests.addBuildOption(bool, "in_memory", in_memory);
+        tests.addBuildOption(?[]const u8, "dbfile", dbfile);
+
+        test_step.dependOn(&tests.step);
+    }
 }


### PR DESCRIPTION
Define the test targets in `build.zig` for a given OS and use that by default when running `zig build test`.

Also use QEMU to run the non-native tests.