### PR TITLE
ci: run the tests with qemu too

### DIFF
--- a/.builds/alpine-edge-amd64.yml
+++ b/.builds/alpine-edge-amd64.yml
@@ -5,6 +5,11 @@ packages:
   - jq
   - sqlite-dev
   - xz
+  - qemu-aarch64
+  - qemu-i386
+  - qemu-riscv64
+  - qemu-mips
+  - qemu-arm
 sources:
   - https://github.com/vrischmann/zig-sqlite
 secrets:
@@ -25,3 +30,11 @@ tasks:
   - test_filesystem: |
       cd zig-sqlite
       TERM=dumb zig build test -Din_memory=false
+
+  - test_in_memory_with_qemu: |
+      cd zig-sqlite
+      TERM=dumb zig build test -Din_memory=true -Denable_qemu=true
+
+  - test_filesystem_with_qemu: |
+      cd zig-sqlite
+      TERM=dumb zig build test -Din_memory=false -Denable_qemu=true

--- a/.builds/debian-stable-amd64.yml
+++ b/.builds/debian-stable-amd64.yml
@@ -4,6 +4,7 @@ packages:
   - curl
   - jq
   - libsqlite3-dev
+  - qemu-user-binfmt
 sources:
   - https://github.com/vrischmann/zig-sqlite
 secrets:
@@ -24,3 +25,11 @@ tasks:
   - test_filesystem: |
       cd zig-sqlite
       TERM=dumb zig build test -Din_memory=false
+
+  - test_in_memory_with_qemu: |
+      cd zig-sqlite
+      TERM=dumb zig build test -Din_memory=true -Denable_qemu=true
+
+  - test_filesystem_with_qemu: |
+      cd zig-sqlite
+      TERM=dumb zig build test -Din_memory=false -Denable_qemu=true


### PR DESCRIPTION
For builds running in a x86_64 VM it should be work fine to run the tests with qemu.