### PR TITLE
enable CI for macOS

### DIFF
--- a/.builds/alpine-edge-amd64.yml
+++ b/.builds/alpine-edge-amd64.yml
@@ -25,14 +25,6 @@ tasks:
       cd zig-sqlite
       TERM=dumb zig build test -Din_memory=true
 
-  - test_filesystem: |
-      cd zig-sqlite
-      TERM=dumb zig build test -Din_memory=false
-
   - test_in_memory_with_qemu: |
       cd zig-sqlite
       TERM=dumb zig build test -Din_memory=true -Denable_qemu=true
-
-  - test_filesystem_with_qemu: |
-      cd zig-sqlite
-      TERM=dumb zig build test -Din_memory=false -Denable_qemu=true

--- a/.builds/debian-stable-aarch64.yml
+++ b/.builds/debian-stable-aarch64.yml
@@ -15,6 +15,7 @@ tasks:
       mv ~/zig-linux-* ~/zig-master
       echo "export PATH=$PATH:~/zig-master" >> ~/.buildenv
 
-  - test_filesystem: |
+  - test_in_memory: |
       cd zig-sqlite
-      TERM=dumb zig build test -Din_memory=false
+      TERM=dumb zig build test -Din_memory=true
+

--- a/.builds/debian-stable-amd64.yml
+++ b/.builds/debian-stable-amd64.yml
@@ -20,14 +20,6 @@ tasks:
       cd zig-sqlite
       TERM=dumb zig build test -Din_memory=true
 
-  - test_filesystem: |
-      cd zig-sqlite
-      TERM=dumb zig build test -Din_memory=false
-
   - test_in_memory_with_qemu: |
       cd zig-sqlite
       TERM=dumb zig build test -Din_memory=true -Denable_qemu=true
-
-  - test_filesystem_with_qemu: |
-      cd zig-sqlite
-      TERM=dumb zig build test -Din_memory=false -Denable_qemu=true

--- a/.builds/freebsd-latest-amd64.yml
+++ b/.builds/freebsd-latest-amd64.yml
@@ -18,7 +18,3 @@ tasks:
   - test_in_memory: |
       cd zig-sqlite
       TERM=dumb zig build test -Din_memory=true
-
-  - test_filesystem: |
-      cd zig-sqlite
-      TERM=dumb zig build test -Din_memory=false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,20 +41,3 @@ jobs:
 
       - name: Run Tests in memory
         run: zig build test -Din_memory=true
-
-  test-with-filesystem:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - uses: goto-bus-stop/setup-zig@v1
-        with:
-          version: master
-
-      - name: Run Tests with filesystem
-        run: zig build test -Din_memory=false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/build.zig
+++ b/build.zig
@@ -122,6 +122,14 @@ const all_test_targets = switch (std.Target.current.cpu.arch) {
                 .bundled = true,
             },
         },
+        .macos => [_]TestTarget{
+            TestTarget{
+                .target = .{
+                    .cpu_arch = .x86_64,
+                },
+                .bundled = true,
+            },
+        },
         else => [_]TestTarget{
             TestTarget{
                 .target = .{},


### PR DESCRIPTION
Uses the GitHub runner so we can only test for `x86_64` at this time.