### PR TITLE
sqlite: expose c import, add 'shared_cache' to init flags

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -5,7 +5,7 @@ const io = std.io;
 const mem = std.mem;
 const testing = std.testing;
 
-const c = @cImport({
+pub const c = @cImport({
     @cInclude("sqlite3.h");
 });
 
@@ -233,6 +233,12 @@ pub const InitOptions = struct {
     /// Defaults to Serialized.
     threading_mode: ThreadingMode = .Serialized,
 
+    /// shared_cache controls whether or not concurrent SQLite
+    /// connections share the same cache.
+    ///
+    /// Defaults to false.
+    shared_cache: bool = false,
+
     /// if provided, diags will be populated in case of failures.
     diags: ?*Diagnostics = null,
 };
@@ -326,6 +332,9 @@ pub const Db = struct {
         flags |= @as(c_int, if (options.open_flags.write) c.SQLITE_OPEN_READWRITE else c.SQLITE_OPEN_READONLY);
         if (options.open_flags.create) {
             flags |= c.SQLITE_OPEN_CREATE;
+        }
+        if (options.shared_cache) {
+            flags |= c.SQLITE_OPEN_SHAREDCACHE;
         }
         switch (options.threading_mode) {
             .MultiThread => flags |= c.SQLITE_OPEN_NOMUTEX,


### PR DESCRIPTION
Expose the C import to sqlite.h. Making a separate call to @cImport outside of the library will cause Zig to regenerate all definitions in sqlite.h. The regenerated definitions (i.e. structs, enums) would not be equivalent to the definitions imported in by this library. This causes problems in the case one wants to manually wrap SQLite structs, pointers, and enums with the helpers provided in this library.

Added 'shared_cache' to init flags in order to allow having the same backing table and statement cache shared amongst all connections pointed to the same database file.