### PR TITLE
sqlite: interpret database path in init flags as uri

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -328,7 +328,7 @@ pub const Db = struct {
         }
 
         // Compute the flags
-        var flags: c_int = 0;
+        var flags: c_int = c.SQLITE_OPEN_URI;
         flags |= @as(c_int, if (options.open_flags.write) c.SQLITE_OPEN_READWRITE else c.SQLITE_OPEN_READONLY);
         if (options.open_flags.create) {
             flags |= c.SQLITE_OPEN_CREATE;


### PR DESCRIPTION
To avoid the need for introducing multiple sqlite.Mode's for addressing all the different possible ways one may initialize a SQLite database, enable the flag SQLITE_OPEN_URI by default.

This allows for initialization options which are not addressed by InitFlags as of yet, such as the option to initialize a shared in-memory SQLite database instance that may be shared across connections in the same address space, to be set via. URI query parameters.

e.g.

```zig
  sqlite.Db.init({
    .mode = .{ .File = "file:hello.db?mode=memory&cache=shared" },
    .open_flags = .{ .create = true, .write = true },
    .threading_mode = .MultiThread,
  });
```