### PR TITLE
Cleanup query parsing

### DIFF
--- a/query.zig
+++ b/query.zig
@@ -19,13 +19,6 @@ const BindMarker = struct {
 
     /// Contains the bind parameter identifier string.
     identifier: ?[]const u8 = null,
-    /// Contains the type of the identifier which is either an integer or a string.
-    identifier_type: IdentifierType = .integer,
-
-    pub const IdentifierType = enum {
-        integer,
-        string,
-    };
 };
 
 pub const ParsedQuery = struct {
@@ -58,7 +51,6 @@ pub const ParsedQuery = struct {
                         parsed_query.bind_markers[parsed_query.nb_bind_markers] = BindMarker{};
                         current_bind_marker_type_pos = 0;
                         current_bind_marker_id_pos = 0;
-                        parsed_query.bind_markers[parsed_query.nb_bind_markers].identifier_type = if (c == '?') .integer else .string;
                         state = .BindMarker;
                         buf[pos] = c;
                         pos += 1;
@@ -346,39 +338,6 @@ test "parsed query: query bind identifier" {
         comptime var parsed_query = ParsedQuery.from(tc.query);
         try testing.expectEqualStrings(tc.expected_query, parsed_query.getQuery());
         try testing.expectEqual(tc.expected_nb_bind_markers, parsed_query.nb_bind_markers);
-    }
-}
-
-test "parsed query: bind markers identifier type" {
-    const testCase = struct {
-        query: []const u8,
-        expected_marker: BindMarker,
-    };
-
-    const testCases = &[_]testCase{ .{
-        .query = "foobar @ABC{usize}",
-        .expected_marker = .{ .identifier_type = .string },
-    }, .{
-        .query = "foobar ?123{text}",
-        .expected_marker = .{ .identifier_type = .integer },
-    }, .{
-        .query = "foobar $abc{blob}",
-        .expected_marker = .{ .identifier_type = .string },
-    }, .{
-        .query = "foobar ?123",
-        .expected_marker = .{ .identifier_type = .integer },
-    }, .{
-        .query = "foobar :abc",
-        .expected_marker = .{ .identifier_type = .string },
-    } };
-
-    inline for (testCases) |tc| {
-        comptime var parsed_query = ParsedQuery.from(tc.query);
-
-        try testing.expectEqual(@as(usize, 1), parsed_query.nb_bind_markers);
-
-        const bind_marker = parsed_query.bind_markers[0];
-        try testing.expectEqual(tc.expected_marker.identifier_type, bind_marker.identifier_type);
     }
 }
 


### PR DESCRIPTION
Both `identifier` and `identifier_type` in `BindMarker` are unused; remove them and clean up the parsing.