### PR TITLE
Support any size for prepare() queries on comptime

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1505,7 +1505,7 @@ pub fn Iterator(comptime Type: type) type {
 ///
 pub fn StatementType(comptime opts: StatementOptions, comptime query: []const u8) type {
     @setEvalBranchQuota(100000);
-    return Statement(opts, ParsedQuery.from(query));
+    return Statement(opts, ParsedQuery(query));
 }
 
 pub const StatementOptions = struct {};
@@ -2001,7 +2001,7 @@ pub const DynamicStatement = struct {
 ///
 /// Look at each function for more complete documentation.
 ///
-pub fn Statement(comptime opts: StatementOptions, comptime query: ParsedQuery) type {
+pub fn Statement(comptime opts: StatementOptions, comptime query: anytype) type {
     _ = opts;
 
     return struct {


### PR DESCRIPTION
Closes #77 with a hacky solution: By making `ParsedQuery` generic on the length of the query, and then with a new `ParsedQueryFromString` helper, to prevent repetition from `ParsedQuery(query.len).from(query)`. Was not ready to change business logic all that much, but removing `from()` and putting it in the type initializer would be a nicer solution, it can be done if that approach is welcome.