### PR TITLE
Run multiple statements in a single query

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -2325,7 +2325,7 @@ test "sqlite: db init" {
 test "sqlite: run multi" {
     var db = try getTestDb();
     defer db.deinit();
-    try db.runMulti("create table a(b int); create table b(c int);", .{});
+    try db.runMulti("create table a(b int);\n\n--test comment\ncreate table b(c int);", .{});
     const val = try db.one(i32, "select max(c) from b", .{}, .{});
     try testing.expectEqual(@as(?i32, 0), val);
 }

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -2322,11 +2322,19 @@ test "sqlite: db init" {
     _ = db;
 }
 
-test "sqlite: run multi" {
+test "sqlite: exec multi" {
     var db = try getTestDb();
     defer db.deinit();
     try db.execMulti("create table a(b int);\n\n--test comment\ncreate table b(c int);", .{});
     const val = try db.one(i32, "select max(c) from b", .{}, .{});
+    try testing.expectEqual(@as(?i32, 0), val);
+}
+
+test "sqlite: exec multi with single statement" {
+    var db = try getTestDb();
+    defer db.deinit();
+    try db.execMulti("create table a(b int);", .{});
+    const val = try db.one(i32, "select max(b) from a", .{}, .{});
     try testing.expectEqual(@as(?i32, 0), val);
 }
 

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -882,12 +882,13 @@ pub const Db = struct {
     ///
     /// Exmaple: 'create table a(); create table b();'
     pub fn runMulti(self: *Self, comptime query: []const u8, options: QueryOptions) !void {
-        while (true) {
-            var sql_tail_ptr: ?[*:0]const u8 = null;
-            options.sql_tail_ptr = &sql_tail_ptr;
+        var new_options = options;
+        var sql_tail_ptr: ?[*:0]const u8 = null;
+        new_options.sql_tail_ptr = &sql_tail_ptr;
 
+        while (true) {
             // continuously prepare and execute
-            var stmt = try self.prepareWithDiags(query, options);
+            var stmt = try self.prepareWithDiags(query, new_options);
             defer stmt.deinit();
             if (sql_tail_ptr == null) break;
 

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -900,8 +900,6 @@ pub const Db = struct {
 
             defer stmt.deinit();
             try stmt.exec(new_options, .{});
-
-            if (sql_tail_ptr == null) break;
         }
     }
 };

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -881,7 +881,7 @@ pub const Db = struct {
     /// bindings to values, but have multiple commands inside.
     ///
     /// Exmaple: 'create table a(); create table b();'
-    pub fn runMulti(self: *Self, comptime query: []const u8, options: QueryOptions) !void {
+    pub fn execMulti(self: *Self, comptime query: []const u8, options: QueryOptions) !void {
         var new_options = options;
         var sql_tail_ptr: ?[*:0]const u8 = null;
         new_options.sql_tail_ptr = &sql_tail_ptr;
@@ -2325,7 +2325,7 @@ test "sqlite: db init" {
 test "sqlite: run multi" {
     var db = try getTestDb();
     defer db.deinit();
-    try db.runMulti("create table a(b int);\n\n--test comment\ncreate table b(c int);", .{});
+    try db.execMulti("create table a(b int);\n\n--test comment\ncreate table b(c int);", .{});
     const val = try db.one(i32, "select max(c) from b", .{}, .{});
     try testing.expectEqual(@as(?i32, 0), val);
 }


### PR DESCRIPTION
This PR adds `Db.runMulti()`, which wraps statement prepare/execution in a loop so that it can process multiple statements from a single query string. SQLite enables this to happen via the `pzTail` argument in `sqlite_prepare` family of functions.

If this function is not welcome, this PR can be reduced to only enabling `pzTail` usage through `QueryOptions`, since with that the logic of `runMulti` can be moved over to library users.