### PR TITLE
Bind runtime slices to queries

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1718,6 +1718,10 @@ pub fn Statement(comptime opts: StatementOptions, comptime query: ParsedQuery) t
         /// The types are checked at comptime.
         fn bind(self: *Self, options: anytype, values: anytype) !void {
             const StructType = @TypeOf(values);
+            if (!comptime std.meta.trait.is(.Struct)(@TypeOf(values))) {
+                @compileError("options passed to Statement.bind must be a struct (DynamicStatement supports runtime slices)");
+            }
+
             const StructTypeInfo = @typeInfo(StructType).Struct;
 
             if (comptime query.nb_bind_markers != StructTypeInfo.fields.len) {
@@ -3100,6 +3104,7 @@ test "sqlite: bind runtime slice" {
         try stmt.exec(.{}, args);
     }
 }
+
 test "sqlite: prepareDynamic" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1444,6 +1444,11 @@ pub const DynamicStatement = struct {
                     try self.bindField(PointerTypeInfo.child, options, "", @intCast(c_int, index), value_to_bind);
                 }
             },
+            .Array => |ArrayTypeInfo| {
+                for (values) |value_to_bind, index| {
+                    try self.bindField(ArrayTypeInfo.child, options, "", @intCast(c_int, index), value_to_bind);
+                }
+            },
             else => @compileError("Unsupported type for values: " ++ @typeName(StructType)),
         }
     }

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1439,14 +1439,18 @@ pub const DynamicStatement = struct {
                 // TODO support other pointer types
                 std.debug.assert(PointerTypeInfo.size == .Slice);
 
-                for (values) |value_to_bind, index| {
-                    std.log.info("awooga {} {}", .{ value_to_bind, index });
-                    try self.bindField(PointerTypeInfo.child, options, "", @intCast(c_int, index), value_to_bind);
+                switch (PointerTypeInfo.size) {
+                    .Slice => {
+                        for (values) |value_to_bind, index| {
+                            try self.bindField(PointerTypeInfo.child, options, "unknown", @intCast(c_int, index), value_to_bind);
+                        }
+                    },
+                    else => @compileError("TODO support pointer size " ++ @tagName(PointerTypeInfo.size)),
                 }
             },
             .Array => |ArrayTypeInfo| {
                 for (values) |value_to_bind, index| {
-                    try self.bindField(ArrayTypeInfo.child, options, "", @intCast(c_int, index), value_to_bind);
+                    try self.bindField(ArrayTypeInfo.child, options, "unknown", @intCast(c_int, index), value_to_bind);
                 }
             },
             else => @compileError("Unsupported type for values: " ++ @typeName(StructType)),

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1421,17 +1421,30 @@ pub const DynamicStatement = struct {
     // If however there are no name bind markers then the behaviour will revert to using the field index in the struct, and the fields order must be correct.
     fn bind(self: *Self, options: anytype, values: anytype) !void {
         const StructType = @TypeOf(values);
-        const StructTypeInfo = @typeInfo(StructType).Struct;
 
-        inline for (StructTypeInfo.fields) |struct_field, struct_field_i| {
-            const field_value = @field(values, struct_field.name);
+        switch (@typeInfo(StructType)) {
+            .Struct => |StructTypeInfo| {
+                inline for (StructTypeInfo.fields) |struct_field, struct_field_i| {
+                    const field_value = @field(values, struct_field.name);
 
-            const i = sqlite3BindParameterIndex(self.stmt, struct_field.name);
-            if (i >= 0) {
-                try self.bindField(struct_field.field_type, options, struct_field.name, i, field_value);
-            } else {
-                try self.bindField(struct_field.field_type, options, struct_field.name, struct_field_i, field_value);
-            }
+                    const i = sqlite3BindParameterIndex(self.stmt, struct_field.name);
+                    if (i >= 0) {
+                        try self.bindField(struct_field.field_type, options, struct_field.name, i, field_value);
+                    } else {
+                        try self.bindField(struct_field.field_type, options, struct_field.name, struct_field_i, field_value);
+                    }
+                }
+            },
+            .Pointer => |PointerTypeInfo| {
+                // TODO support other pointer types
+                std.debug.assert(PointerTypeInfo.size == .Slice);
+
+                for (values) |value_to_bind, index| {
+                    std.log.info("awooga {} {}", .{ value_to_bind, index });
+                    try self.bindField(PointerTypeInfo.child, options, "", @intCast(c_int, index), value_to_bind);
+                }
+            },
+            else => @compileError("Unsupported type for values: " ++ @typeName(StructType)),
         }
     }
 

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -3078,6 +3078,28 @@ test "sqlite: bind custom type" {
     }
 }
 
+test "sqlite: bind runtime slice" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var allocator = arena.allocator();
+
+    // creating array list on heap so that it's deemed runtime size
+    var list = std.ArrayList([]const u8).init(allocator);
+    defer list.deinit();
+    try list.append("this is some data");
+    const args = list.toOwnedSlice();
+
+    var db = try getTestDb();
+    defer db.deinit();
+    try addTestData(&db);
+
+    {
+        // insertion
+        var stmt = try db.prepareDynamic("INSERT INTO article(data) VALUES(?)");
+        defer stmt.deinit();
+        try stmt.exec(.{}, args);
+    }
+}
 test "sqlite: prepareDynamic" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();


### PR DESCRIPTION
When using `execDynamic`, you can have a runtime-known number of parameters in the query, however the current way of binding the parameters requires the values to be comptime-known.

This PR allows slices of form `[]T` to be passed as the `values` parameter, binding it to the statement with a runtime loop instead. Not sure how I should approach setting the `field_name` parameter to bindField, as it is comptime (so I'm just setting it to empty string). Any suggestions?

This was manually tested, but if this idea moves forward on being upstreamed, I plan to add it to the test suite.