### PR TITLE
Make errorFromResultCode public

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -15,6 +15,7 @@ pub const Text = @import("query.zig").Text;
 pub const ParsedQuery = @import("query.zig").ParsedQuery;
 
 const errors = @import("errors.zig");
+pub const errorFromResultCode = errors.errorFromResultCode;
 pub const Error = errors.Error;
 
 const logger = std.log.scoped(.sqlite);


### PR DESCRIPTION
Example: [We aren't exposing the sqlite backup functions](https://github.com/lun-4/awtfdb/blob/mistress/src/main.zig#L208), but it would be a waste to require the library user to copy-paste `errorFromResultCode`'s implementation.