### PR TITLE
Fix compilation with old SQLite versions

### DIFF
--- a/errors.zig
+++ b/errors.zig
@@ -132,6 +132,17 @@ pub fn errorFromResultCode(code: c_int) Error {
     // TODO(vincent): can we do something with comptime here ?
     // The version number is always static and defined by sqlite.
 
+    // These errors are only available since 3.22.0.
+    if (c.SQLITE_VERSION_NUMBER >= 3022000) {
+        switch (code) {
+            c.SQLITE_ERROR_MISSING_COLLSEQ => return error.SQLiteErrorMissingCollSeq,
+            c.SQLITE_ERROR_RETRY => return error.SQLiteErrorRetry,
+            c.SQLITE_READONLY_CANTINIT => return error.SQLiteReadOnlyCantInit,
+            c.SQLITE_READONLY_DIRECTORY => return error.SQLiteReadOnlyDirectory,
+            else => {},
+        }
+    }
+
     // These errors are only available since 3.25.0.
     if (c.SQLITE_VERSION_NUMBER >= 3025000) {
         switch (code) {
@@ -196,9 +207,6 @@ pub fn errorFromResultCode(code: c_int) Error {
         c.SQLITE_NOTICE => return error.SQLiteNotice,
         c.SQLITE_WARNING => return error.SQLiteWarning,
 
-        c.SQLITE_ERROR_MISSING_COLLSEQ => return error.SQLiteErrorMissingCollSeq,
-        c.SQLITE_ERROR_RETRY => return error.SQLiteErrorRetry,
-
         c.SQLITE_IOERR_READ => return error.SQLiteIOErrRead,
         c.SQLITE_IOERR_SHORT_READ => return error.SQLiteIOErrShortRead,
         c.SQLITE_IOERR_WRITE => return error.SQLiteIOErrWrite,
@@ -247,8 +255,6 @@ pub fn errorFromResultCode(code: c_int) Error {
         c.SQLITE_READONLY_CANTLOCK => return error.SQLiteReadOnlyCantLock,
         c.SQLITE_READONLY_ROLLBACK => return error.SQLiteReadOnlyRollback,
         c.SQLITE_READONLY_DBMOVED => return error.SQLiteReadOnlyDBMoved,
-        c.SQLITE_READONLY_CANTINIT => return error.SQLiteReadOnlyCantInit,
-        c.SQLITE_READONLY_DIRECTORY => return error.SQLiteReadOnlyDirectory,
 
         c.SQLITE_ABORT_ROLLBACK => return error.SQLiteAbortRollback,
 

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -695,20 +695,34 @@ pub const Db = struct {
     ///
     /// The flags SQLITE_UTF16LE, SQLITE_UTF16BE are not supported yet. SQLITE_UTF8 is the default and always on.
     ///
+    /// SQLITE_DIRECTONLY is only available on SQLite >= 3.30.0 so we create a different type based on the SQLite version.
+    ///
     /// TODO(vincent): allow these flags when we know how to handle UTF16 data.
-    pub const CreateFunctionFlag = struct {
+    /// TODO(vincent): can we refactor this somehow to share the common stuff ?
+    pub const CreateFunctionFlag = if (c.SQLITE_VERSION_NUMBER >= 3030000) struct {
         /// Equivalent to SQLITE_DETERMINISTIC
         deterministic: bool = true,
         /// Equivalent to SQLITE_DIRECTONLY
         direct_only: bool = true,
 
-        fn toCFlags(self: *const CreateFunctionFlag) c_int {
+        fn toCFlags(self: *const @This()) c_int {
             var flags: c_int = c.SQLITE_UTF8;
             if (self.deterministic) {
                 flags |= c.SQLITE_DETERMINISTIC;
             }
             if (self.direct_only) {
                 flags |= c.SQLITE_DIRECTONLY;
+            }
+            return flags;
+        }
+    } else struct {
+        /// Equivalent to SQLITE_DETERMINISTIC
+        deterministic: bool = true,
+
+        fn toCFlags(self: *const @This()) c_int {
+            var flags: c_int = c.SQLITE_UTF8;
+            if (self.deterministic) {
+                flags |= c.SQLITE_DETERMINISTIC;
             }
             return flags;
         }


### PR DESCRIPTION
Specifically:
* some error codes are only available with SQLite >= 3.22.0
* `SQLITE_DIRECTONLY` is only available since SQLite 3.30.0

If a user uses the bunded source code it's never going to be a problem but this can matter if they use the system sqlite.