### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest, ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-18.04, ubuntu-latest, ubuntu-22.04, windows-latest, macos-latest, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-18.04, ubuntu-latest, ubuntu-22.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  create:
   push:
     paths:
     - '**.zig'


### PR DESCRIPTION
* Test on all Ubuntu runners (Ubuntu 18.04 uses SQLite 3.22 so it will be helpful to test that we're still compatible).
* Test on new Ubuntu and macOS runners
* Run the workflow on refs creation too