### PR TITLE
require SQLite >= 3.21.0

### DIFF
--- a/c.zig
+++ b/c.zig
@@ -1,3 +1,14 @@
 pub const c = @cImport({
     @cInclude("sqlite3.h");
 });
+
+// versionGreaterThanOrEqualTo returns true if the SQLite version is >= to the major.minor.patch provided.
+pub fn versionGreaterThanOrEqualTo(major: u8, minor: u8, patch: u8) bool {
+    return c.SQLITE_VERSION_NUMBER >= @as(u32, major) * 1000000 + @as(u32, minor) * 1000 + @as(u32, patch);
+}
+
+comptime {
+    if (!versionGreaterThanOrEqualTo(3, 21, 0)) {
+        @compileError("must use SQLite >= 3.21.0");
+    }
+}

--- a/errors.zig
+++ b/errors.zig
@@ -2,8 +2,7 @@ const std = @import("std");
 const mem = std.mem;
 
 const c = @import("c.zig").c;
-
-const versionGreaterThanOrEqualTo = @import("sqlite.zig").versionGreaterThanOrEqualTo;
+const versionGreaterThanOrEqualTo = @import("c.zig").versionGreaterThanOrEqualTo;
 
 pub const SQLiteExtendedIOError = error{
     SQLiteIOErrRead,

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -8,6 +8,7 @@ const mem = std.mem;
 const testing = std.testing;
 
 const c = @import("c.zig").c;
+const versionGreaterThanOrEqualTo = @import("c.zig").versionGreaterThanOrEqualTo;
 
 pub const ParsedQuery = @import("query.zig").ParsedQuery;
 
@@ -19,11 +20,6 @@ const getLastDetailedErrorFromDb = errors.getLastDetailedErrorFromDb;
 const getDetailedErrorFromResultCode = errors.getDetailedErrorFromResultCode;
 
 const logger = std.log.scoped(.sqlite);
-
-// versionGreaterThanOrEqualTo returns true if the SQLite version is >= to the major.minor.patch provided.
-pub fn versionGreaterThanOrEqualTo(major: u8, minor: u8, patch: u8) bool {
-    return c.SQLITE_VERSION_NUMBER >= @as(u32, major) * 1000000 + @as(u32, minor) * 1000 + @as(u32, patch);
-}
 
 /// Text is used to represent a SQLite TEXT value when binding a parameter or reading a column.
 pub const Text = struct { data: []const u8 };


### PR DESCRIPTION
After some testing it turns out we need at least SQLite 3.21.0 to
compile.

We _could_ work around this and make zig-sqlite work with older SQLite
versions but I don't think it's necessary because:
* "old" distributions like Debian Buster, RHEL 8 ship with SQLite >
  3.21.0
* in any case if people want to build for OSes where SQLite is too old
  they can use the bundled source code.