### PR TITLE
change some build api usage for building bundled sqlite3

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Now it's just a matter of linking your `build.zig` target(s) to this library ins
 ```zig
 exe.linkLibC();
 exe.linkLibrary(sqlite);
-exe.addPackage(.{ .name = "sqlite", .path = "third_party/zig-sqlite/sqlite.zig" });
+exe.addPackage(.{ .name = "sqlite", .path = .{ .path = "third_party/zig-sqlite/sqlite.zig" } });
 exe.addIncludeDir("third_party/zig-sqlite/c");
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ If you want to use the bundled sqlite source code file, first you need to add it
 ```zig
 const sqlite = b.addStaticLibrary("sqlite", null);
 sqlite.addCSourceFile("third_party/zig-sqlite/c/sqlite3.c", &[_][]const u8{"-std=c99"});
-sqlite.addIncludeDir("third_party/zig-sqlite/c");
 sqlite.linkLibC();
 ```
 
@@ -120,6 +119,7 @@ Now it's just a matter of linking your `build.zig` target(s) to this library ins
 exe.linkLibC();
 exe.linkLibrary(sqlite);
 exe.addPackage(.{ .name = "sqlite", .path = "third_party/zig-sqlite/sqlite.zig" });
+exe.addIncludeDir("third_party/zig-sqlite/c");
 ```
 
 If you're building with glibc you must make sure that the version used is at least 2.28.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Now it's just a matter of linking your `build.zig` target(s) to this library ins
 ```zig
 exe.linkLibC();
 exe.linkLibrary(sqlite);
-exe.addPackage(.{ .name = "sqlite", .path = .{ .path = "third_party/zig-sqlite/sqlite.zig" } });
+exe.addPackagePath("sqlite", "third_party/zig-sqlite/sqlite.zig");
 exe.addIncludeDir("third_party/zig-sqlite/c");
 ```
 


### PR DESCRIPTION
Hello, thank you for a fantastic library. I could not build with bundled sqlite3 following to current readme. Change some build api usage resolves this issue. My Zig version is `0.9.1` from latest release.