### PR TITLE
Allow Db.exec_multi to take query with spaces

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -2345,7 +2345,7 @@ test "sqlite: db init" {
 test "sqlite: exec multi" {
     var db = try getTestDb();
     defer db.deinit();
-    try db.execMulti("create table a(b int);\n\n--test comment\ncreate table b(c int);", .{});
+    try db.execMulti("create table a(b int);\n\n--test comment\ncreate table b(c int);\n", .{});
     const val = try db.one(i32, "select max(c) from b", .{}, .{});
     try testing.expectEqual(@as(?i32, 0), val);
 }

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -856,7 +856,8 @@ pub const Db = struct {
             // values to bind in this case)
             var stmt: DynamicStatement = undefined;
             if (sql_tail_ptr != null) {
-                const new_query = std.mem.span(sql_tail_ptr.?);
+                var new_query = std.mem.span(sql_tail_ptr.?);
+                while (new_query.len > 0 and std.ascii.isSpace(new_query[0])) new_query = new_query[1..];
                 if (new_query.len == 0) break;
                 stmt = try self.prepareDynamicWithDiags(new_query, new_options);
             } else {


### PR DESCRIPTION
This allows to keep SQL queries in a separate file where spaces and
newlines are very common.