### PR TITLE
Fix compile error with Zig 0.10.0

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -340,7 +340,7 @@ pub const Db = struct {
         switch (options.mode) {
             .File => |path| {
                 var db: ?*c.sqlite3 = undefined;
-                const result = c.sqlite3_open_v2(path, &db, flags, null);
+                const result = c.sqlite3_open_v2(path.ptr, &db, flags, null);
                 if (result != c.SQLITE_OK or db == null) {
                     if (db) |v| {
                         diags.err = getLastDetailedErrorFromDb(v);


### PR DESCRIPTION
Fixes the following error:

```
sqlite.zig:343:50: error: expected type '[*c]const u8', found '[:0]const u8'
                const result = c.sqlite3_open_v2(path, &db, flags, null);
                                                 ^~~~
```