### PR TITLE
Fix build failures on latest Zig

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -3360,7 +3360,7 @@ test "sqlite: bind custom type" {
         var i: usize = 0;
         while (i < 20) : (i += 1) {
             var my_data: MyData = undefined;
-            mem.set(u8, &my_data.data, @intCast(u8, i));
+            @memset(&my_data.data, @intCast(u8, i));
 
             var arena = heap.ArenaAllocator.init(testing.allocator);
             defer arena.deinit();
@@ -3390,7 +3390,7 @@ test "sqlite: bind custom type" {
 
         for (rows, 0..) |row, i| {
             var exp_data: MyData = undefined;
-            mem.set(u8, &exp_data.data, @intCast(u8, i));
+            @memset(&exp_data.data, @intCast(u8, i));
 
             try testing.expectEqualSlices(u8, &exp_data.data, &row.data.data);
         }

--- a/tools/preprocess_files.zig
+++ b/tools/preprocess_files.zig
@@ -247,7 +247,7 @@ fn preprocessSqlite3ExtHeaderFile(gpa: mem.Allocator) !void {
 
 pub fn main() !void {
     var gpa = heap.GeneralPurposeAllocator(.{}){};
-    defer if (gpa.deinit()) debug.panic("leaks detected\n", .{});
+    defer if (gpa.deinit() == .leak) debug.panic("leaks detected\n", .{});
 
     try preprocessSqlite3HeaderFile(gpa.allocator());
     try preprocessSqlite3ExtHeaderFile(gpa.allocator());


### PR DESCRIPTION
Now the correct build APIs and `@memset` builtin are used.

Unfortunately `@cImport` fails for `aarch64` and `riscv64` targets, but I'm not sure how to fix this.

Not sure if I did this right so feel free to let me know