### PR TITLE
support packed structs as columns backed by their int type

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1445,7 +1445,7 @@ pub fn Iterator(comptime Type: type) type {
                         @compileError("enum column " ++ @typeName(FieldType) ++ " must have a BaseType of either string or int");
                     },
                     .Struct => |TI| {
-                        if (TI.layout == .Packed) return @bitCast(FieldType, try self.readInt(TI.backing_integer.?, i));
+                        if (TI.layout == .Packed) return @bitCast(try self.readInt(TI.backing_integer.?, i));
                         const inner_value = try self.readField(FieldType.BaseType, options, i);
                         return try FieldType.readField(options.allocator, inner_value);
                     },
@@ -1653,7 +1653,7 @@ pub const DynamicStatement = struct {
                 },
                 .Struct => |info| {
                     if (info.layout == .Packed) {
-                        try self.bindField(info.backing_integer.?, options, field_name, i, @bitCast(info.backing_integer.?, field));
+                        try self.bindField(info.backing_integer.?, options, field_name, i, @bitCast(field));
                         return;
                     }
                     if (!comptime std.meta.trait.hasFn("bindField")(FieldType)) {


### PR DESCRIPTION
# Description

Adds support for packed structs to be used as a column type backed by their int type without having to manually add the readField/bindField methods

# Checklist

- [ ] I added tests for my changes and they pass
