### PR TITLE
readField remove unreachable and support default value in string backed enums

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1436,8 +1436,7 @@ pub fn Iterator(comptime Type: type) type {
                             // The inner value is never returned to the user, we must free it ourselves.
                             defer options.allocator.free(inner_value);
 
-                            // TODO(vincent): don't use unreachable
-                            return std.meta.stringToEnum(FieldType, inner_value) orelse unreachable;
+                            return std.meta.stringToEnum(FieldType, inner_value) orelse FieldType.default;
                         }
                         if (@typeInfo(FieldType.BaseType) == .Int) {
                             return @enumFromInt(@as(TI.tag_type, @intCast(inner_value)));

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -2228,6 +2228,7 @@ const TestUser = struct {
         //
 
         pub const BaseType = []const u8;
+        pub const default = .red;
     };
 };
 


### PR DESCRIPTION
# Description

fixes the TODO and adds a proper escape hatch for when readField for stringly enums fails

# Checklist

- [ ] I added tests for my changes and they pass
