### PR TITLE
Fix build for recent Zig C naming changes

### DIFF
--- a/vtab.zig
+++ b/vtab.zig
@@ -232,7 +232,7 @@ pub const BestIndexBuilder = struct {
         var index_info = self.index_info;
 
         // Populate the constraint usage
-        var constraint_usage: []c.sqlite3_index_constraint_usage = index_info.aConstraintUsage[0..self.constraints.len];
+        var constraint_usage: []c.struct_sqlite3_index_constraint_usage_4 = index_info.aConstraintUsage[0..self.constraints.len];
         for (self.constraints, 0..) |constraint, i| {
             constraint_usage[i].argvIndex = constraint.usage.argv_index;
             constraint_usage[i].omit = if (constraint.usage.omit) 1 else 0;


### PR DESCRIPTION
# Description

Zig recently introduced a [change](https://github.com/ziglang/zig/commit/9ea2076663730ab6ac9cad5cb5f84e58198d4d95) to prevent C variable names conflicting with type names that I think is the reason compilation started to fail. I don't understand the change enough to evaluate whether the result of `sqlite3_index_constraint_usage` being mangled to `struct_sqlite3_index_constraint_usage_4` is valid, but my change fixes the build.

# Checklist

- [ ] I added tests for my changes and they pass

No additional code so I didn't change the tests. Note that I can't get tests to run on my local machine as discussed previously but I no longer get errors compiling.
