### PR TITLE
Fix test build step for Mac OS X

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -254,6 +254,7 @@ pub fn build(b: *std.Build) !void {
             .root_source_file = .{ .path = "sqlite.zig" },
             .single_threaded = test_target.single_threaded,
         });
+        const run_tests = b.addRunArtifact(tests);
 
         if (bundled) {
             const lib = b.addStaticLibrary(.{
@@ -287,7 +288,7 @@ pub fn build(b: *std.Build) !void {
         tests_options.addOption(bool, "in_memory", in_memory);
         tests_options.addOption(?[]const u8, "dbfile", dbfile);
 
-        test_step.dependOn(&tests.step);
+        test_step.dependOn(&run_tests.step);
     }
 
     // Fuzzing


### PR DESCRIPTION
# Description

Fixes the test build step issue I was having on Mac OS X. May also fix for others. Depends on #133.

Output on Mac OS X 13.x:
```
❯ zig build test -Din_memory=true --summary all
Build Summary: 5/5 steps succeeded; 52/52 tests passed
test success
└─ run x86_64-native-Debug-multi 52 passed 184ms MaxRSS:5M
   └─ zig test x86_64-native-Debug-multi Debug x86_64-native success 3s MaxRSS:322M
      ├─ zig build-lib sqlite Debug x86_64-native success 5s MaxRSS:496M
      └─ options success
```

# Checklist

- [ ] I added tests for my changes and they pass

Build changes only, so no new tests