### PR TITLE
Patch for the new 0.12.0-dev.1664+8ca4a5240 version that points out local variables which aren't mutated

### DIFF
--- a/query.zig
+++ b/query.zig
@@ -276,7 +276,7 @@ test "parsed query: bind markers types" {
 
         inline for (testCases) |tc| {
             @setEvalBranchQuota(100000);
-            comptime var parsed_query = ParsedQuery(tc.query);
+            const parsed_query = ParsedQuery(tc.query);
 
             try testing.expectEqual(1, parsed_query.nb_bind_markers);
 
@@ -324,7 +324,7 @@ test "parsed query: bind markers identifier" {
     };
 
     inline for (testCases) |tc| {
-        comptime var parsed_query = ParsedQuery(tc.query);
+        const parsed_query = ParsedQuery(tc.query);
 
         try testing.expectEqual(@as(usize, 1), parsed_query.nb_bind_markers);
 

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1086,7 +1086,7 @@ pub fn Iterator(comptime Type: type) type {
             var dummy_diags = Diagnostics{};
             var diags = options.diags orelse &dummy_diags;
 
-            var result = c.sqlite3_step(self.stmt);
+            const result = c.sqlite3_step(self.stmt);
             if (result == c.SQLITE_DONE) {
                 return null;
             }

--- a/test.zig
+++ b/test.zig
@@ -9,7 +9,7 @@ pub fn getTestDb() !Db {
     var buf: [1024]u8 = undefined;
     var fba = std.heap.FixedBufferAllocator.init(&buf);
 
-    var mode = dbMode(fba.allocator());
+    const mode = dbMode(fba.allocator());
 
     return try Db.init(.{
         .open_flags = .{

--- a/vtab.zig
+++ b/vtab.zig
@@ -198,7 +198,7 @@ pub const BestIndexBuilder = struct {
     const InitError = error{} || mem.Allocator.Error || ConstraintOpFromCodeError;
 
     fn init(allocator: mem.Allocator, index_info: *c.sqlite3_index_info) InitError!Self {
-        var res = Self{
+        const res = Self{
             .allocator = allocator,
             .index_info = index_info,
             .id_str_buffer = std.ArrayList(u8).init(allocator),
@@ -538,7 +538,7 @@ pub const ModuleArgument = union(enum) {
 const ParseModuleArgumentsError = error{} || mem.Allocator.Error;
 
 fn parseModuleArguments(allocator: mem.Allocator, argc: c_int, argv: [*c]const [*c]const u8) ParseModuleArgumentsError![]ModuleArgument {
-    var res = try allocator.alloc(ModuleArgument, @intCast(argc));
+    const res = try allocator.alloc(ModuleArgument, @intCast(argc));
     errdefer allocator.free(res);
 
     for (res, 0..) |*marg, i| {
@@ -585,7 +585,7 @@ pub fn VirtualTable(
         const InitError = error{} || mem.Allocator.Error || Table.InitError;
 
         fn init(module_context: *ModuleContext, table: *Table) InitError!*Self {
-            var res = try module_context.allocator.create(Self);
+            const res = try module_context.allocator.create(Self);
             res.* = .{
                 .vtab = mem.zeroes(c.sqlite3_vtab),
                 .module_context = module_context,
@@ -615,7 +615,7 @@ pub fn VirtualTable(
         const InitError = error{} || mem.Allocator.Error || Table.Cursor.InitError;
 
         fn init(module_context: *ModuleContext, table: *Table) InitError!*Self {
-            var res = try module_context.allocator.create(Self);
+            const res = try module_context.allocator.create(Self);
             errdefer module_context.allocator.destroy(res);
 
             res.* = .{
@@ -839,7 +839,7 @@ pub fn VirtualTable(
         fn filterArgsFromCPointer(allocator: mem.Allocator, argc: c_int, argv: [*c]?*c.sqlite3_value) FilterArgsFromCPointerError![]FilterArg {
             const size: usize = @intCast(argc);
 
-            var res = try allocator.alloc(FilterArg, size);
+            const res = try allocator.alloc(FilterArg, size);
             for (res, 0..) |*item, i| {
                 item.* = .{
                     .value = argv[i],
@@ -860,7 +860,7 @@ pub fn VirtualTable(
 
             const id = IndexIdentifier.fromC(idx_num, idx_str);
 
-            var args = filterArgsFromCPointer(arena.allocator(), argc, argv) catch |err| {
+            const args = filterArgsFromCPointer(arena.allocator(), argc, argv) catch |err| {
                 logger.err("unable to create filter args, err: {!}", .{err});
                 return c.SQLITE_ERROR;
             };
@@ -1008,7 +1008,7 @@ const TestVirtualTable = struct {
 
             var rand = std.rand.DefaultPrng.init(204882485);
 
-            var tmp = try allocator.alloc(Row, n);
+            const tmp = try allocator.alloc(Row, n);
             for (tmp) |*s| {
                 const foo_value = data[rand.random().intRangeLessThan(usize, 0, data.len)];
                 const bar_value = data[rand.random().intRangeLessThan(usize, 0, data.len)];
@@ -1122,7 +1122,7 @@ const TestVirtualTableCursor = struct {
     pub const InitError = error{} || mem.Allocator.Error;
 
     pub fn init(allocator: mem.Allocator, parent: *TestVirtualTable) InitError!*TestVirtualTableCursor {
-        var res = try allocator.create(TestVirtualTableCursor);
+        const res = try allocator.create(TestVirtualTableCursor);
         res.* = .{
             .allocator = allocator,
             .parent = parent,
@@ -1275,7 +1275,7 @@ test "parse module arguments" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    var args = try allocator.alloc([*c]const u8, 20);
+    const args = try allocator.alloc([*c]const u8, 20);
     for (args, 0..) |*arg, i| {
         const tmp = try fmt.allocPrintZ(allocator, "arg={d}", .{i});
         arg.* = @ptrCast(tmp);


### PR DESCRIPTION
#Description 

The compiler now seems to point out local variables that should be defined as const instead of var or comptime var as they aren't mutated in the program.

# Checklist

I didn't add any tests, but pointed a program of mine which uses zig-sqlite to this fork/patched branch of mine and it now compiles again.
