### PR TITLE
Update to sqlite 3.44.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
     .name = "sqlite",
-    .version = "3.43.1",
+    .version = "3.43.2",
     .paths = .{"."},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,4 +1,5 @@
 .{
     .name = "sqlite",
-    .version = "0.0.0",
+    .version = "3.43.1",
+    .paths = .{"."},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
     .name = "sqlite",
-    .version = "3.43.2",
+    .version = "3.44.0",
     .paths = .{"."},
 }

--- a/c/sqlite3.h
+++ b/c/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.43.1"
-#define SQLITE_VERSION_NUMBER 3043001
-#define SQLITE_SOURCE_ID      "2023-09-11 12:01:27 2d3a40c05c49e1a49264912b1a05bc2143ac0e7c3df588276ce80a4cbc9bd1b0"
+#define SQLITE_VERSION        "3.43.2"
+#define SQLITE_VERSION_NUMBER 3043002
+#define SQLITE_SOURCE_ID      "2023-10-10 12:14:04 4310099cce5a487035fa535dd3002c59ac7f1d1bec68d7cf317fd3e769484790"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/c/sqlite3.h
+++ b/c/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.43.2"
-#define SQLITE_VERSION_NUMBER 3043002
-#define SQLITE_SOURCE_ID      "2023-10-10 12:14:04 4310099cce5a487035fa535dd3002c59ac7f1d1bec68d7cf317fd3e769484790"
+#define SQLITE_VERSION        "3.44.0"
+#define SQLITE_VERSION_NUMBER 3044000
+#define SQLITE_SOURCE_ID      "2023-11-01 11:23:50 17129ba1ff7f0daf37100ee82d507aef7827cf38de1866e2633096ae6ad81301"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -2127,7 +2127,7 @@ struct sqlite3_mem_methods {
 ** is stored in each sorted record and the required column values loaded
 ** from the database as records are returned in sorted order. The default
 ** value for this option is to never use this optimization. Specifying a
-** negative value for this option restores the default behaviour.
+** negative value for this option restores the default behavior.
 ** This option is only available if SQLite is compiled with the
 ** [SQLITE_ENABLE_SORTER_REFERENCES] compile-time option.
 **
@@ -2302,7 +2302,7 @@ struct sqlite3_mem_methods {
 ** database handle, SQLite checks if this will mean that there are now no
 ** connections at all to the database. If so, it performs a checkpoint
 ** operation before closing the connection. This option may be used to
-** override this behaviour. The first parameter passed to this operation
+** override this behavior. The first parameter passed to this operation
 ** is an integer - positive to disable checkpoints-on-close, or zero (the
 ** default) to enable them, and negative to leave the setting unchanged.
 ** The second parameter is a pointer to an integer
@@ -3955,6 +3955,7 @@ SQLITE_API void sqlite3_free_filename(sqlite3_filename);
 **
 ** ^The sqlite3_errmsg() and sqlite3_errmsg16() return English-language
 ** text that describes the error, as either UTF-8 or UTF-16 respectively.
+** (See how SQLite handles [invalid UTF] for exceptions to this rule.)
 ** ^(Memory to hold the error message string is managed internally.
 ** The application does not need to worry about freeing the result.
 ** However, the error string might be overwritten or deallocated by
@@ -5325,6 +5326,7 @@ SQLITE_API int sqlite3_finalize(sqlite3_stmt *pStmt);
 */
 SQLITE_API int sqlite3_reset(sqlite3_stmt *pStmt);
 
+
 /*
 ** CAPI3REF: Create Or Redefine SQL Functions
 ** KEYWORDS: {function creation routines}
@@ -5879,32 +5881,32 @@ SQLITE_API sqlite3 *sqlite3_context_db_handle(sqlite3_context*);
 ** METHOD: sqlite3_context
 **
 ** These functions may be used by (non-aggregate) SQL functions to
-** associate metadata with argument values. If the same value is passed to
-** multiple invocations of the same SQL function during query execution, under
-** some circumstances the associated metadata may be preserved.  An example
-** of where this might be useful is in a regular-expression matching
-** function. The compiled version of the regular expression can be stored as
-** metadata associated with the pattern string.
+** associate auxiliary data with argument values. If the same argument
+** value is passed to multiple invocations of the same SQL function during
+** query execution, under some circumstances the associated auxiliary data
+** might be preserved.  An example of where this might be useful is in a
+** regular-expression matching function. The compiled version of the regular
+** expression can be stored as auxiliary data associated with the pattern string.
 ** Then as long as the pattern string remains the same,
 ** the compiled regular expression can be reused on multiple
 ** invocations of the same function.
 **
-** ^The sqlite3_get_auxdata(C,N) interface returns a pointer to the metadata
+** ^The sqlite3_get_auxdata(C,N) interface returns a pointer to the auxiliary data
 ** associated by the sqlite3_set_auxdata(C,N,P,X) function with the Nth argument
 ** value to the application-defined function.  ^N is zero for the left-most
-** function argument.  ^If there is no metadata
+** function argument.  ^If there is no auxiliary data
 ** associated with the function argument, the sqlite3_get_auxdata(C,N) interface
 ** returns a NULL pointer.
 **
-** ^The sqlite3_set_auxdata(C,N,P,X) interface saves P as metadata for the N-th
-** argument of the application-defined function.  ^Subsequent
+** ^The sqlite3_set_auxdata(C,N,P,X) interface saves P as auxiliary data for the
+** N-th argument of the application-defined function.  ^Subsequent
 ** calls to sqlite3_get_auxdata(C,N) return P from the most recent
-** sqlite3_set_auxdata(C,N,P,X) call if the metadata is still valid or
-** NULL if the metadata has been discarded.
+** sqlite3_set_auxdata(C,N,P,X) call if the auxiliary data is still valid or
+** NULL if the auxiliary data has been discarded.
 ** ^After each call to sqlite3_set_auxdata(C,N,P,X) where X is not NULL,
 ** SQLite will invoke the destructor function X with parameter P exactly
-** once, when the metadata is discarded.
-** SQLite is free to discard the metadata at any time, including: <ul>
+** once, when the auxiliary data is discarded.
+** SQLite is free to discard the auxiliary data at any time, including: <ul>
 ** <li> ^(when the corresponding function parameter changes)^, or
 ** <li> ^(when [sqlite3_reset()] or [sqlite3_finalize()] is called for the
 **      SQL statement)^, or
@@ -5920,7 +5922,7 @@ SQLITE_API sqlite3 *sqlite3_context_db_handle(sqlite3_context*);
 ** function implementation should not make any use of P after
 ** sqlite3_set_auxdata() has been called.
 **
-** ^(In practice, metadata is preserved between function calls for
+** ^(In practice, auxiliary data is preserved between function calls for
 ** function parameters that are compile-time constants, including literal
 ** values and [parameters] and expressions composed from the same.)^
 **
@@ -5930,10 +5932,67 @@ SQLITE_API sqlite3 *sqlite3_context_db_handle(sqlite3_context*);
 **
 ** These routines must be called from the same thread in which
 ** the SQL function is running.
+**
+** See also: [sqlite3_get_clientdata()] and [sqlite3_set_clientdata()].
 */
 SQLITE_API void *sqlite3_get_auxdata(sqlite3_context*, int N);
 SQLITE_API void sqlite3_set_auxdata(sqlite3_context*, int N, void*, void (*)(void*));
 
+/*
+** CAPI3REF: Database Connection Client Data
+** METHOD: sqlite3
+**
+** These functions are used to associate one or more named pointers
+** with a [database connection].
+** A call to sqlite3_set_clientdata(D,N,P,X) causes the pointer P
+** to be attached to [database connection] D using name N.  Subsequent
+** calls to sqlite3_get_clientdata(D,N) will return a copy of pointer P
+** or a NULL pointer if there were no prior calls to
+** sqlite3_set_clientdata() with the same values of D and N.
+** Names are compared using strcmp() and are thus case sensitive.
+**
+** If P and X are both non-NULL, then the destructor X is invoked with
+** argument P on the first of the following occurrences:
+** <ul>
+** <li> An out-of-memory error occurs during the call to
+**      sqlite3_set_clientdata() which attempts to register pointer P.
+** <li> A subsequent call to sqlite3_set_clientdata(D,N,P,X) is made
+**      with the same D and N parameters.
+** <li> The database connection closes.  SQLite does not make any guarantees
+**      about the order in which destructors are called, only that all
+**      destructors will be called exactly once at some point during the
+**      database connection closing process.
+** </ul>
+**
+** SQLite does not do anything with client data other than invoke
+** destructors on the client data at the appropriate time.  The intended
+** use for client data is to provide a mechanism for wrapper libraries
+** to store additional information about an SQLite database connection.
+**
+** There is no limit (other than available memory) on the number of different
+** client data pointers (with different names) that can be attached to a
+** single database connection.  However, the implementation is optimized
+** for the case of having only one or two different client data names.
+** Applications and wrapper libraries are discouraged from using more than
+** one client data name each.
+**
+** There is no way to enumerate the client data pointers
+** associated with a database connection.  The N parameter can be thought
+** of as a secret key such that only code that knows the secret key is able
+** to access the associated data.
+**
+** Security Warning:  These interfaces should not be exposed in scripting
+** languages or in other circumstances where it might be possible for an
+** an attacker to invoke them.  Any agent that can invoke these interfaces
+** can probably also take control of the process.
+**
+** Database connection client data is only available for SQLite
+** version 3.44.0 ([dateof:3.44.0]) and later.
+**
+** See also: [sqlite3_set_auxdata()] and [sqlite3_get_auxdata()].
+*/
+SQLITE_API void *sqlite3_get_clientdata(sqlite3*,const char*);
+SQLITE_API int sqlite3_set_clientdata(sqlite3*, const char*, void*, void(*)(void*));
 
 /*
 ** CAPI3REF: Constants Defining Special Destructor Behavior
@@ -6566,7 +6625,7 @@ SQLITE_API int sqlite3_db_readonly(sqlite3 *db, const char *zDbName);
 SQLITE_API int sqlite3_txn_state(sqlite3*,const char *zSchema);
 
 /*
-** CAPI3REF: Allowed return values from [sqlite3_txn_state()]
+** CAPI3REF: Allowed return values from sqlite3_txn_state()
 ** KEYWORDS: {transaction state}
 **
 ** These constants define the current transaction state of a database file.
@@ -6698,7 +6757,7 @@ SQLITE_API void *sqlite3_rollback_hook(sqlite3*, void(*)(void *), void*);
 ** ^Each call to the sqlite3_autovacuum_pages() interface overrides all
 ** previous invocations for that database connection.  ^If the callback
 ** argument (C) to sqlite3_autovacuum_pages(D,C,P,X) is a NULL pointer,
-** then the autovacuum steps callback is cancelled.  The return value
+** then the autovacuum steps callback is canceled.  The return value
 ** from sqlite3_autovacuum_pages() is normally SQLITE_OK, but might
 ** be some other error code if something goes wrong.  The current
 ** implementation will only return SQLITE_OK or SQLITE_MISUSE, but other
@@ -7217,6 +7276,10 @@ struct sqlite3_module {
   /* The methods above are in versions 1 and 2 of the sqlite_module object.
   ** Those below are for version 3 and greater. */
   int (*xShadowName)(const char*);
+  /* The methods above are in versions 1 through 3 of the sqlite_module object.
+  ** Those below are for version 4 and greater. */
+  int (*xIntegrity)(sqlite3_vtab *pVTab, const char *zSchema,
+                    const char *zTabName, int mFlags, char **pzErr);
 };
 
 /*
@@ -7704,7 +7767,7 @@ SQLITE_API int sqlite3_blob_reopen(sqlite3_blob *, sqlite3_int64);
 ** code is returned and the transaction rolled back.
 **
 ** Calling this function with an argument that is not a NULL pointer or an
-** open blob handle results in undefined behaviour. ^Calling this routine
+** open blob handle results in undefined behavior. ^Calling this routine
 ** with a null pointer (such as would be returned by a failed call to
 ** [sqlite3_blob_open()]) is a harmless no-op. ^Otherwise, if this function
 ** is passed a valid open blob handle, the values returned by the
@@ -8184,6 +8247,7 @@ SQLITE_API int sqlite3_test_control(int op, ...);
 #define SQLITE_TESTCTRL_PRNG_SAVE                5
 #define SQLITE_TESTCTRL_PRNG_RESTORE             6
 #define SQLITE_TESTCTRL_PRNG_RESET               7  /* NOT USED */
+#define SQLITE_TESTCTRL_FK_NO_ACTION             7
 #define SQLITE_TESTCTRL_BITVEC_TEST              8
 #define SQLITE_TESTCTRL_FAULT_INSTALL            9
 #define SQLITE_TESTCTRL_BENIGN_MALLOC_HOOKS     10
@@ -9245,8 +9309,8 @@ SQLITE_API int sqlite3_backup_pagecount(sqlite3_backup *p);
 ** blocked connection already has a registered unlock-notify callback,
 ** then the new callback replaces the old.)^ ^If sqlite3_unlock_notify() is
 ** called with a NULL pointer as its second argument, then any existing
-** unlock-notify callback is cancelled. ^The blocked connections
-** unlock-notify callback may also be cancelled by closing the blocked
+** unlock-notify callback is canceled. ^The blocked connections
+** unlock-notify callback may also be canceled by closing the blocked
 ** connection using [sqlite3_close()].
 **
 ** The unlock-notify callback is not reentrant. If an application invokes
@@ -10549,6 +10613,13 @@ SQLITE_API SQLITE_EXPERIMENTAL int sqlite3_snapshot_recover(sqlite3 *db, const c
 ** SQLITE_SERIALIZE_NOCOPY bit is set but no contiguous copy
 ** of the database exists.
 **
+** After the call, if the SQLITE_SERIALIZE_NOCOPY bit had been set,
+** the returned buffer content will remain accessible and unchanged
+** until either the next write operation on the connection or when
+** the connection is closed, and applications must not modify the
+** buffer. If the bit had been clear, the returned buffer will not
+** be accessed by SQLite after the call.
+**
 ** A call to sqlite3_serialize(D,S,P,F) might return NULL even if the
 ** SQLITE_SERIALIZE_NOCOPY bit is omitted from argument F if a memory
 ** allocation error occurs.
@@ -10597,6 +10668,9 @@ SQLITE_API unsigned char *sqlite3_serialize(
 ** SQLite will try to increase the buffer size using sqlite3_realloc64()
 ** if writes on the database cause it to grow larger than M bytes.
 **
+** Applications must not modify the buffer P or invalidate it before
+** the database connection D is closed.
+**
 ** The sqlite3_deserialize() interface will fail with SQLITE_BUSY if the
 ** database is currently in a read transaction or is involved in a backup
 ** operation.
@@ -10604,6 +10678,13 @@ SQLITE_API unsigned char *sqlite3_serialize(
 ** It is not possible to deserialized into the TEMP database.  If the
 ** S argument to sqlite3_deserialize(D,S,P,N,M,F) is "temp" then the
 ** function returns SQLITE_ERROR.
+**
+** The deserialized database should not be in [WAL mode].  If the database
+** is in WAL mode, then any attempt to use the database file will result
+** in an [SQLITE_CANTOPEN] error.  The application can set the
+** [file format version numbers] (bytes 18 and 19) of the input database P
+** to 0x01 prior to invoking sqlite3_deserialize(D,S,P,N,M,F) to force the
+** database file into rollback mode and work around this limitation.
 **
 ** If sqlite3_deserialize(D,S,P,N,M,F) fails for any reason and if the
 ** SQLITE_DESERIALIZE_FREEONCLOSE bit is set in argument F, then
@@ -11678,6 +11759,18 @@ SQLITE_API int sqlite3changeset_concat(
 
 
 /*
+** CAPI3REF: Upgrade the Schema of a Changeset/Patchset
+*/
+SQLITE_API int sqlite3changeset_upgrade(
+  sqlite3 *db,
+  const char *zDb,
+  int nIn, const void *pIn,       /* Input changeset */
+  int *pnOut, void **ppOut        /* OUT: Inverse of input */
+);
+
+
+
+/*
 ** CAPI3REF: Changegroup Handle
 **
 ** A changegroup is an object used to combine two or more
@@ -11722,6 +11815,38 @@ typedef struct sqlite3_changegroup sqlite3_changegroup;
 ** versions sqlite3changegroup_add_strm() and sqlite3changegroup_output_strm().
 */
 SQLITE_API int sqlite3changegroup_new(sqlite3_changegroup **pp);
+
+/*
+** CAPI3REF: Add a Schema to a Changegroup
+** METHOD: sqlite3_changegroup_schema
+**
+** This method may be used to optionally enforce the rule that the changesets
+** added to the changegroup handle must match the schema of database zDb
+** ("main", "temp", or the name of an attached database). If
+** sqlite3changegroup_add() is called to add a changeset that is not compatible
+** with the configured schema, SQLITE_SCHEMA is returned and the changegroup
+** object is left in an undefined state.
+**
+** A changeset schema is considered compatible with the database schema in
+** the same way as for sqlite3changeset_apply(). Specifically, for each
+** table in the changeset, there exists a database table with:
+**
+** <ul>
+**   <li> The name identified by the changeset, and
+**   <li> at least as many columns as recorded in the changeset, and
+**   <li> the primary key columns in the same position as recorded in
+**        the changeset.
+** </ul>
+**
+** The output of the changegroup object always has the same schema as the
+** database nominated using this function. In cases where changesets passed
+** to sqlite3changegroup_add() have fewer columns than the corresponding table
+** in the database schema, these are filled in using the default column
+** values from the database schema. This makes it possible to combined
+** changesets that have different numbers of columns for a single table
+** within a changegroup, provided that they are otherwise compatible.
+*/
+SQLITE_API int sqlite3changegroup_schema(sqlite3_changegroup*, sqlite3*, const char *zDb);
 
 /*
 ** CAPI3REF: Add A Changeset To A Changegroup
@@ -11791,13 +11916,18 @@ SQLITE_API int sqlite3changegroup_new(sqlite3_changegroup **pp);
 ** If the new changeset contains changes to a table that is already present
 ** in the changegroup, then the number of columns and the position of the
 ** primary key columns for the table must be consistent. If this is not the
-** case, this function fails with SQLITE_SCHEMA. If the input changeset
-** appears to be corrupt and the corruption is detected, SQLITE_CORRUPT is
-** returned. Or, if an out-of-memory condition occurs during processing, this
-** function returns SQLITE_NOMEM. In all cases, if an error occurs the state
-** of the final contents of the changegroup is undefined.
+** case, this function fails with SQLITE_SCHEMA. Except, if the changegroup
+** object has been configured with a database schema using the
+** sqlite3changegroup_schema() API, then it is possible to combine changesets
+** with different numbers of columns for a single table, provided that
+** they are otherwise compatible.
 **
-** If no error occurs, SQLITE_OK is returned.
+** If the input changeset appears to be corrupt and the corruption is
+** detected, SQLITE_CORRUPT is returned. Or, if an out-of-memory condition
+** occurs during processing, this function returns SQLITE_NOMEM.
+**
+** In all cases, if an error occurs the state of the final contents of the
+** changegroup is undefined. If no error occurs, SQLITE_OK is returned.
 */
 SQLITE_API int sqlite3changegroup_add(sqlite3_changegroup*, int nData, void *pData);
 
@@ -12062,10 +12192,17 @@ SQLITE_API int sqlite3changeset_apply_v2(
 **    <li>an insert change if all fields of the conflicting row match
 **        the row being inserted.
 **    </ul>
+**
+** <dt>SQLITE_CHANGESETAPPLY_FKNOACTION <dd>
+**   If this flag it set, then all foreign key constraints in the target
+**   database behave as if they were declared with "ON UPDATE NO ACTION ON
+**   DELETE NO ACTION", even if they are actually CASCADE, RESTRICT, SET NULL
+**   or SET DEFAULT.
 */
 #define SQLITE_CHANGESETAPPLY_NOSAVEPOINT   0x0001
 #define SQLITE_CHANGESETAPPLY_INVERT        0x0002
 #define SQLITE_CHANGESETAPPLY_IGNORENOOP    0x0004
+#define SQLITE_CHANGESETAPPLY_FKNOACTION    0x0008
 
 /*
 ** CAPI3REF: Constants Passed To The Conflict Handler

--- a/c/sqlite3ext.h
+++ b/c/sqlite3ext.h
@@ -363,6 +363,9 @@ struct sqlite3_api_routines {
   int (*is_interrupted)(sqlite3*);
   /* Version 3.43.0 and later */
   int (*stmt_explain)(sqlite3_stmt*,int);
+  /* Version 3.44.0 and later */
+  void *(*get_clientdata)(sqlite3*,const char*);
+  int (*set_clientdata)(sqlite3*, const char*, void*, void(*)(void*));
 };
 
 /*
@@ -693,6 +696,9 @@ typedef int (*sqlite3_loadext_entry)(
 #define sqlite3_is_interrupted         sqlite3_api->is_interrupted
 /* Version 3.43.0 and later */
 #define sqlite3_stmt_explain           sqlite3_api->stmt_explain
+/* Version 3.44.0 and later */
+#define sqlite3_get_clientdata         sqlite3_api->get_clientdata
+#define sqlite3_set_clientdata         sqlite3_api->set_clientdata
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)

--- a/query.zig
+++ b/query.zig
@@ -276,7 +276,7 @@ test "parsed query: bind markers types" {
 
         inline for (testCases) |tc| {
             @setEvalBranchQuota(100000);
-            comptime var parsed_query = ParsedQuery(tc.query);
+            const parsed_query = comptime ParsedQuery(tc.query);
 
             try testing.expectEqual(1, parsed_query.nb_bind_markers);
 
@@ -324,7 +324,7 @@ test "parsed query: bind markers identifier" {
     };
 
     inline for (testCases) |tc| {
-        comptime var parsed_query = ParsedQuery(tc.query);
+        const parsed_query = comptime ParsedQuery(tc.query);
 
         try testing.expectEqual(@as(usize, 1), parsed_query.nb_bind_markers);
 

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -106,7 +106,7 @@ pub const Blob = struct {
             return 0;
         }
 
-        var tmp_buffer = blk: {
+        const tmp_buffer = blk: {
             const remaining: usize = @as(usize, @intCast(self.size)) - @as(usize, @intCast(self.offset));
             break :blk if (buffer.len > remaining) buffer[0..remaining] else buffer;
         };
@@ -401,7 +401,7 @@ pub const Db = struct {
     ///     const journal_mode = try db.pragma([]const u8, allocator, .{}, "journal_mode", null);
     ///
     pub fn pragmaAlloc(self: *Self, comptime Type: type, allocator: mem.Allocator, options: QueryOptions, comptime name: []const u8, comptime arg: ?[]const u8) !?Type {
-        comptime var query = getPragmaQuery(name, arg);
+        const query = comptime getPragmaQuery(name, arg);
 
         var stmt = try self.prepare(query);
         defer stmt.deinit();
@@ -423,7 +423,7 @@ pub const Db = struct {
     ///
     /// This cannot allocate memory. If your pragma command returns text you must use an array or call `pragmaAlloc`.
     pub fn pragma(self: *Self, comptime Type: type, options: QueryOptions, comptime name: []const u8, comptime arg: ?[]const u8) !?Type {
-        comptime var query = getPragmaQuery(name, arg);
+        const query = comptime getPragmaQuery(name, arg);
 
         var stmt = try self.prepareWithDiags(query, options);
         defer stmt.deinit();
@@ -936,7 +936,7 @@ pub const Savepoint = struct {
 
         var buffer: [256]u8 = undefined;
         var fba = std.heap.FixedBufferAllocator.init(&buffer);
-        var allocator = fba.allocator();
+        const allocator = fba.allocator();
 
         const commit_query = try std.fmt.allocPrint(allocator, "RELEASE SAVEPOINT {s}", .{name});
         const rollback_query = try std.fmt.allocPrint(allocator, "ROLLBACK TRANSACTION TO SAVEPOINT {s}", .{name});
@@ -1028,7 +1028,7 @@ pub fn Iterator(comptime Type: type) type {
             var dummy_diags = Diagnostics{};
             var diags = options.diags orelse &dummy_diags;
 
-            var result = c.sqlite3_step(self.stmt);
+            const result = c.sqlite3_step(self.stmt);
             if (result == c.SQLITE_DONE) {
                 return null;
             }
@@ -1086,7 +1086,7 @@ pub fn Iterator(comptime Type: type) type {
             var dummy_diags = Diagnostics{};
             var diags = options.diags orelse &dummy_diags;
 
-            var result = c.sqlite3_step(self.stmt);
+            const result = c.sqlite3_step(self.stmt);
             if (result == c.SQLITE_DONE) {
                 return null;
             }
@@ -1516,7 +1516,7 @@ pub const DynamicStatement = struct {
     fn prepare(db: *Db, query: []const u8, options: QueryOptions, flags: c_uint) PrepareError!Self {
         var dummy_diags = Diagnostics{};
         var diags = options.diags orelse &dummy_diags;
-        var stmt = blk: {
+        const stmt = blk: {
             var tmp: ?*c.sqlite3_stmt = undefined;
             const result = c.sqlite3_prepare_v3(
                 db.db,
@@ -2312,7 +2312,7 @@ test "sqlite: exec multi with single statement" {
 test "sqlite: db pragma" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -2425,7 +2425,7 @@ test "sqlite: db execAlloc" {
 test "sqlite: read a single user into a struct" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -2434,7 +2434,7 @@ test "sqlite: read a single user into a struct" {
     var stmt = try db.prepare("SELECT * FROM user WHERE id = ?{usize}");
     defer stmt.deinit();
 
-    var rows = try stmt.all(TestUser, allocator, .{}, .{
+    const rows = try stmt.all(TestUser, allocator, .{}, .{
         .id = @as(usize, 20),
     });
     for (rows) |row| {
@@ -2465,7 +2465,7 @@ test "sqlite: read a single user into a struct" {
 
     // Read a row with db.oneAlloc()
     {
-        var row = try db.oneAlloc(
+        const row = try db.oneAlloc(
             struct {
                 name: Text,
                 id: usize,
@@ -2488,7 +2488,7 @@ test "sqlite: read a single user into a struct" {
 test "sqlite: read all users into a struct" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -2497,7 +2497,7 @@ test "sqlite: read all users into a struct" {
     var stmt = try db.prepare("SELECT * FROM user");
     defer stmt.deinit();
 
-    var rows = try stmt.all(TestUser, allocator, .{}, .{});
+    const rows = try stmt.all(TestUser, allocator, .{}, .{});
     try testing.expectEqual(@as(usize, 3), rows.len);
     for (rows, 0..) |row, i| {
         const exp = test_users[i];
@@ -2511,7 +2511,7 @@ test "sqlite: read all users into a struct" {
 test "sqlite: read in an anonymous struct" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -2547,7 +2547,7 @@ test "sqlite: read in an anonymous struct" {
 test "sqlite: read in a Text struct" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -2556,7 +2556,7 @@ test "sqlite: read in a Text struct" {
     var stmt = try db.prepare("SELECT name, id, age FROM user WHERE id = ?{usize}");
     defer stmt.deinit();
 
-    var row = try stmt.oneAlloc(
+    const row = try stmt.oneAlloc(
         struct {
             name: Text,
             id: usize,
@@ -2577,7 +2577,7 @@ test "sqlite: read in a Text struct" {
 test "sqlite: read a single text value" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -2659,7 +2659,7 @@ test "sqlite: read a single integer value" {
         var stmt: StatementType(.{}, query) = try db.prepare(query);
         defer stmt.deinit();
 
-        var age = try stmt.one(typ, .{}, .{
+        const age = try stmt.one(typ, .{}, .{
             .id = @as(usize, 20),
         });
         try testing.expect(age != null);
@@ -2671,7 +2671,7 @@ test "sqlite: read a single integer value" {
 test "sqlite: read a single value into an enum backed by an integer" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -2718,7 +2718,7 @@ test "sqlite: read a single value into an enum backed by an integer" {
 test "sqlite: read a single value into an enum backed by a string" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -2819,7 +2819,7 @@ test "sqlite: bind string literal" {
 test "sqlite: bind pointer" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -2842,7 +2842,7 @@ test "sqlite: bind pointer" {
 test "sqlite: read pointers" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -2952,7 +2952,7 @@ test "sqlite: statement reset" {
 test "sqlite: statement iterator" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -3038,7 +3038,7 @@ test "sqlite: statement iterator" {
 test "sqlite: blob open, reopen" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -3197,7 +3197,7 @@ test "sqlite: exec with diags, failing statement" {
 test "sqlite: savepoint with no failures" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -3226,7 +3226,7 @@ test "sqlite: savepoint with no failures" {
     var stmt = try db.prepare("SELECT data, author_id FROM article ORDER BY id ASC");
     defer stmt.deinit();
 
-    var rows = try stmt.all(
+    const rows = try stmt.all(
         struct {
             data: []const u8,
             author_id: usize,
@@ -3246,7 +3246,7 @@ test "sqlite: savepoint with no failures" {
 test "sqlite: two nested savepoints with inner failure" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -3280,7 +3280,7 @@ test "sqlite: two nested savepoints with inner failure" {
     var stmt = try db.prepare("SELECT data, author_id FROM article");
     defer stmt.deinit();
 
-    var rows = try stmt.all(
+    const rows = try stmt.all(
         struct {
             data: []const u8,
             author_id: usize,
@@ -3297,7 +3297,7 @@ test "sqlite: two nested savepoints with inner failure" {
 test "sqlite: two nested savepoints with outer failure" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -3325,7 +3325,7 @@ test "sqlite: two nested savepoints with outer failure" {
     var stmt = try db.prepare("SELECT 1 FROM article");
     defer stmt.deinit();
 
-    var rows = try stmt.all(usize, allocator, .{}, .{});
+    const rows = try stmt.all(usize, allocator, .{}, .{});
     try testing.expectEqual(@as(usize, 0), rows.len);
 }
 
@@ -3400,7 +3400,7 @@ test "sqlite: bind custom type" {
 test "sqlite: bind runtime slice" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     // creating array list on heap so that it's deemed runtime size
     var list = std.ArrayList([]const u8).init(allocator);
@@ -3423,7 +3423,7 @@ test "sqlite: bind runtime slice" {
 test "sqlite: prepareDynamic" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -3465,7 +3465,7 @@ test "sqlite: prepareDynamic" {
 test "sqlite: oneDynamic" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     var db = try getTestDb();
     defer db.deinit();
@@ -3713,7 +3713,7 @@ test "sqlite: create aggregate function with no aggregate context" {
         }.step,
         struct {
             fn finalize(fctx: FunctionContext) u32 {
-                var ctx = fctx.userContext(*MyContext) orelse return 0;
+                const ctx = fctx.userContext(*MyContext) orelse return 0;
                 return ctx.sum;
             }
         }.finalize,
@@ -3761,13 +3761,13 @@ test "sqlite: create aggregate function with an aggregate context" {
         null,
         struct {
             fn step(fctx: FunctionContext, input: u32) void {
-                var ctx = fctx.aggregateContext(*u32) orelse return;
+                const ctx = fctx.aggregateContext(*u32) orelse return;
                 ctx.* += input;
             }
         }.step,
         struct {
             fn finalize(fctx: FunctionContext) u32 {
-                var ctx = fctx.aggregateContext(*u32) orelse return 0;
+                const ctx = fctx.aggregateContext(*u32) orelse return 0;
                 return ctx.*;
             }
         }.finalize,

--- a/test.zig
+++ b/test.zig
@@ -9,7 +9,7 @@ pub fn getTestDb() !Db {
     var buf: [1024]u8 = undefined;
     var fba = std.heap.FixedBufferAllocator.init(&buf);
 
-    var mode = dbMode(fba.allocator());
+    const mode = dbMode(fba.allocator());
 
     return try Db.init(.{
         .open_flags = .{

--- a/vtab.zig
+++ b/vtab.zig
@@ -198,7 +198,7 @@ pub const BestIndexBuilder = struct {
     const InitError = error{} || mem.Allocator.Error || ConstraintOpFromCodeError;
 
     fn init(allocator: mem.Allocator, index_info: *c.sqlite3_index_info) InitError!Self {
-        var res = Self{
+        const res = Self{
             .allocator = allocator,
             .index_info = index_info,
             .id_str_buffer = std.ArrayList(u8).init(allocator),
@@ -538,7 +538,7 @@ pub const ModuleArgument = union(enum) {
 const ParseModuleArgumentsError = error{} || mem.Allocator.Error;
 
 fn parseModuleArguments(allocator: mem.Allocator, argc: c_int, argv: [*c]const [*c]const u8) ParseModuleArgumentsError![]ModuleArgument {
-    var res = try allocator.alloc(ModuleArgument, @intCast(argc));
+    const res = try allocator.alloc(ModuleArgument, @intCast(argc));
     errdefer allocator.free(res);
 
     for (res, 0..) |*marg, i| {
@@ -585,7 +585,7 @@ pub fn VirtualTable(
         const InitError = error{} || mem.Allocator.Error || Table.InitError;
 
         fn init(module_context: *ModuleContext, table: *Table) InitError!*Self {
-            var res = try module_context.allocator.create(Self);
+            const res = try module_context.allocator.create(Self);
             res.* = .{
                 .vtab = mem.zeroes(c.sqlite3_vtab),
                 .module_context = module_context,
@@ -615,7 +615,7 @@ pub fn VirtualTable(
         const InitError = error{} || mem.Allocator.Error || Table.Cursor.InitError;
 
         fn init(module_context: *ModuleContext, table: *Table) InitError!*Self {
-            var res = try module_context.allocator.create(Self);
+            const res = try module_context.allocator.create(Self);
             errdefer module_context.allocator.destroy(res);
 
             res.* = .{
@@ -839,7 +839,7 @@ pub fn VirtualTable(
         fn filterArgsFromCPointer(allocator: mem.Allocator, argc: c_int, argv: [*c]?*c.sqlite3_value) FilterArgsFromCPointerError![]FilterArg {
             const size: usize = @intCast(argc);
 
-            var res = try allocator.alloc(FilterArg, size);
+            const res = try allocator.alloc(FilterArg, size);
             for (res, 0..) |*item, i| {
                 item.* = .{
                     .value = argv[i],
@@ -860,7 +860,7 @@ pub fn VirtualTable(
 
             const id = IndexIdentifier.fromC(idx_num, idx_str);
 
-            var args = filterArgsFromCPointer(arena.allocator(), argc, argv) catch |err| {
+            const args = filterArgsFromCPointer(arena.allocator(), argc, argv) catch |err| {
                 logger.err("unable to create filter args, err: {!}", .{err});
                 return c.SQLITE_ERROR;
             };
@@ -1008,7 +1008,7 @@ const TestVirtualTable = struct {
 
             var rand = std.rand.DefaultPrng.init(204882485);
 
-            var tmp = try allocator.alloc(Row, n);
+            const tmp = try allocator.alloc(Row, n);
             for (tmp) |*s| {
                 const foo_value = data[rand.random().intRangeLessThan(usize, 0, data.len)];
                 const bar_value = data[rand.random().intRangeLessThan(usize, 0, data.len)];
@@ -1122,7 +1122,7 @@ const TestVirtualTableCursor = struct {
     pub const InitError = error{} || mem.Allocator.Error;
 
     pub fn init(allocator: mem.Allocator, parent: *TestVirtualTable) InitError!*TestVirtualTableCursor {
-        var res = try allocator.create(TestVirtualTableCursor);
+        const res = try allocator.create(TestVirtualTableCursor);
         res.* = .{
             .allocator = allocator,
             .parent = parent,
@@ -1275,7 +1275,7 @@ test "parse module arguments" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    var args = try allocator.alloc([*c]const u8, 20);
+    const args = try allocator.alloc([*c]const u8, 20);
     for (args, 0..) |*arg, i| {
         const tmp = try fmt.allocPrintZ(allocator, "arg={d}", .{i});
         arg.* = @ptrCast(tmp);


### PR DESCRIPTION
# Description

* Mostly updated to 3.44.0
* Some redundant changes already merged due to new Zig master throwing errors for `var` instead of `const` if the variable didn't change
* Changed `comptime var x = y` to `const x = comptime y`

# Checklist

- I've tested on my local environment.
