### PR TITLE
Fix for deprecated std.mem.copy

### DIFF
--- a/query.zig
+++ b/query.zig
@@ -149,7 +149,7 @@ pub fn ParsedQuery(comptime query: []const u8) ParsedQueryState(query.len) {
         .query_len = pos,
     };
 
-    std.mem.copy(u8, &parsed_state.query, &buf);
+    std.mem.copyForwards(u8, &parsed_state.query, &buf);
 
     return parsed_state;
 }

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1240,7 +1240,7 @@ pub fn Iterator(comptime Type: type) type {
                             if (data != null) {
                                 const ptr = @as([*c]const u8, @ptrCast(data))[0..size];
 
-                                mem.copy(u8, ret[0..], ptr);
+                                mem.copyForwards(u8, ret[0..], ptr);
                             }
                         },
                         else => @compileError("cannot read into array of " ++ @typeName(arr.child)),


### PR DESCRIPTION
# Description

The function std.mem.copy was removed (see this link for details https://github.com/ziglang/zig/pull/18143).
I believe this should lead to the same results.
Edit: Another solution could be to use @memcpy.

# Checklist

I didn't write any tests for it, I only this branch again in my project and it compiles again and works for what I do.
