### PR TITLE
Add distinct EmptyQuery error / Fix zig fmt on query.zig

### DIFF
--- a/query.zig
+++ b/query.zig
@@ -106,7 +106,7 @@ pub fn ParsedQuery(comptime query: []const u8) ParsedQueryState(query.len) {
                     if (!isNamedIdentifierChar(c)) {
                         // This marks the end of the named bind marker.
                         state = .start;
-                        const name = buf[hold_pos..pos - 1];
+                        const name = buf[hold_pos .. pos - 1];
                         if (bindMarkerForName(bind_markers[0..nb_bind_markers], name) == null) {
                             bind_markers[nb_bind_markers].name = name;
                             nb_bind_markers += 1;


### PR DESCRIPTION
# Description

Add distinct EmptyQuery error so execMulti can be run on .sql schema files with  `@embedFile` for example.
Fix the zig fmt errors in query.zig

# Checklist

- [ ] I added tests for my changes and they pass
