### PR TITLE
build.zig: Configure module to be used downstream

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -267,8 +267,6 @@ pub fn build(b: *std.Build) !void {
     const target = b.resolveTargetQuery(query);
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("sqlite", .{ .root_source_file = .{ .path = "sqlite.zig" } });
-
     const sqlite_lib = b.addStaticLibrary(.{
         .name = "sqlite",
         .target = target,
@@ -284,6 +282,14 @@ pub fn build(b: *std.Build) !void {
     sqlite_lib.installHeader("c/sqlite3.h", "sqlite3.h");
 
     b.installArtifact(sqlite_lib);
+
+    // Create the public 'sqlite' module to be exported
+    const sqlite_mod = b.addModule("sqlite", .{
+        .root_source_file = .{ .path = "sqlite.zig" },
+        .link_libc = true,
+    });
+    sqlite_mod.addIncludePath(.{ .path = "c/" });
+    sqlite_mod.linkLibrary(sqlite_lib);
 
     // Tool to preprocess the sqlite header files.
     //


### PR DESCRIPTION
# Description

With the recent Zig build system changes, Modules now work much like CMake library targets, in that settings applied to one module are applied to any other module which imports that module as a dependency.  For example, with my current changes, I'm able to do the following (at least for my use case):

```zig
// Example setup in build.zig
const sqlite = b.dependency("sqlite", .{
    .target = target,
    .optimize = optimize,
    .use_bundled = true,
});
exe.root_module.addImport("sqlite", sqlite.module("sqlite"));
// Note that we no longer need to access and link to the "sqlite" artifact,
// nor add any include directories
```
