### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const sqlite = b.dependency("sqlite", .{
     .optimize = optimize,
 });
 
-exe.addModule("sqlite", sqlite.module("sqlite"));
+exe.root_module.addImport("sqlite", sqlite.module("sqlite"));
 
 // links the bundled sqlite3, so leave this out if you link the system one
 exe.linkLibrary(sqlite.artifact("sqlite"));


### PR DESCRIPTION
Update installation instructions for latest zig master

# Description

It seems the 'addModule' method was removed in latest zig master, and the way to add dependencies is now to use '.root_module.addImport'. 

It helps to have the readme describe the exact steps required to get going with the library to reduce friction for developers trying to use the library.