### PR TITLE
fix: update for latest version of zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -281,7 +281,9 @@ pub fn build(b: *std.Build) !void {
         .flags = &[_][]const u8{"-std=c99"},
     });
     sqlite_lib.linkLibC();
-    sqlite_lib.installHeader("c/sqlite3.h", "sqlite3.h");
+    sqlite_lib.installHeader(.{
+        .path = "c/sqlite3.h",
+    }, "sqlite3.h");
 
     b.installArtifact(sqlite_lib);
 

--- a/vtab.zig
+++ b/vtab.zig
@@ -766,7 +766,7 @@ pub fn VirtualTable(
 
             //
 
-            const state = @fieldParentPtr(State, "vtab", vtab);
+            const state: State = @fieldParentPtr("vtab", vtab);
 
             var arena = heap.ArenaAllocator.init(state.module_context.allocator);
             defer arena.deinit();
@@ -788,7 +788,7 @@ pub fn VirtualTable(
         }
 
         fn xDisconnect(vtab: [*c]c.sqlite3_vtab) callconv(.C) c_int {
-            const state = @fieldParentPtr(State, "vtab", vtab);
+            const state: State = @fieldParentPtr("vtab", vtab);
             state.deinit();
 
             return c.SQLITE_OK;
@@ -803,7 +803,7 @@ pub fn VirtualTable(
         }
 
         fn xOpen(vtab: [*c]c.sqlite3_vtab, vtab_cursor: [*c][*c]c.sqlite3_vtab_cursor) callconv(.C) c_int {
-            const state = @fieldParentPtr(State, "vtab", vtab);
+            const state: State = @fieldParentPtr("vtab", vtab);
 
             const cursor_state = CursorState.init(state.module_context, state.table) catch |err| {
                 logger.err("unable to create cursor state, err: {!}", .{err});
@@ -815,14 +815,14 @@ pub fn VirtualTable(
         }
 
         fn xClose(vtab_cursor: [*c]c.sqlite3_vtab_cursor) callconv(.C) c_int {
-            const cursor_state = @fieldParentPtr(CursorState, "vtab_cursor", vtab_cursor);
+            const cursor_state: CursorState = @fieldParentPtr("vtab_cursor", vtab_cursor);
             cursor_state.deinit();
 
             return c.SQLITE_OK;
         }
 
         fn xEof(vtab_cursor: [*c]c.sqlite3_vtab_cursor) callconv(.C) c_int {
-            const cursor_state = @fieldParentPtr(CursorState, "vtab_cursor", vtab_cursor);
+            const cursor_state: CursorState = @fieldParentPtr("vtab_cursor", vtab_cursor);
             const cursor = cursor_state.cursor;
 
             var arena = heap.ArenaAllocator.init(cursor_state.module_context.allocator);
@@ -859,7 +859,7 @@ pub fn VirtualTable(
         }
 
         fn xFilter(vtab_cursor: [*c]c.sqlite3_vtab_cursor, idx_num: c_int, idx_str: [*c]const u8, argc: c_int, argv: [*c]?*c.sqlite3_value) callconv(.C) c_int {
-            const cursor_state = @fieldParentPtr(CursorState, "vtab_cursor", vtab_cursor);
+            const cursor_state: CursorState = @fieldParentPtr("vtab_cursor", vtab_cursor);
             const cursor = cursor_state.cursor;
 
             var arena = heap.ArenaAllocator.init(cursor_state.module_context.allocator);
@@ -884,7 +884,7 @@ pub fn VirtualTable(
         }
 
         fn xNext(vtab_cursor: [*c]c.sqlite3_vtab_cursor) callconv(.C) c_int {
-            const cursor_state = @fieldParentPtr(CursorState, "vtab_cursor", vtab_cursor);
+            const cursor_state: CursorState = @fieldParentPtr("vtab_cursor", vtab_cursor);
             const cursor = cursor_state.cursor;
 
             var arena = heap.ArenaAllocator.init(cursor_state.module_context.allocator);
@@ -902,7 +902,7 @@ pub fn VirtualTable(
         }
 
         fn xColumn(vtab_cursor: [*c]c.sqlite3_vtab_cursor, ctx: ?*c.sqlite3_context, n: c_int) callconv(.C) c_int {
-            const cursor_state = @fieldParentPtr(CursorState, "vtab_cursor", vtab_cursor);
+            const cursor_state: CursorState = @fieldParentPtr("vtab_cursor", vtab_cursor);
             const cursor = cursor_state.cursor;
 
             var arena = heap.ArenaAllocator.init(cursor_state.module_context.allocator);
@@ -945,7 +945,7 @@ pub fn VirtualTable(
         }
 
         fn xRowid(vtab_cursor: [*c]c.sqlite3_vtab_cursor, row_id_ptr: [*c]c.sqlite3_int64) callconv(.C) c_int {
-            const cursor_state = @fieldParentPtr(CursorState, "vtab_cursor", vtab_cursor);
+            const cursor_state: CursorState = @fieldParentPtr("vtab_cursor", vtab_cursor);
             const cursor = cursor_state.cursor;
 
             var arena = heap.ArenaAllocator.init(cursor_state.module_context.allocator);


### PR DESCRIPTION
# fix: update for latest version of zig

This PR will fix for running on the latest commit of zig. Two main changes required to get working was `installHeader` needs to use `lazyPath` and `@fieldParentPtr` no longer takes the type as a param.

Also the readme should be updated because addAnonymousModule was removed, however I'm not entirely sure how/what needs to be changed since I followed the build.zig https://github.com/vrischmann/zig-sqlite-demo and everything works as expected.