### PR TITLE
Workaround SQLITE_TRANSIENT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,14 +32,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: goto-bus-stop/setup-zig@v2
+
+      - name: Setup zig
+        uses: goto-bus-stop/setup-zig@v2
         with:
           version: master
 
-      - uses: actions/cache@v4
+      - name: Restore cache
+        uses: actions/cache@v4
         with:
           path: |
             zig-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-12]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +40,6 @@ jobs:
           version: master
 
       - uses: actions/cache@v4
-        if: ${{ matrix.os != 'windows-latest' }}
         with:
           path: |
             zig-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,11 @@ jobs:
         with:
           version: master
 
+      - name: Install qemu
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y qemu-user-binfmt
+
       - name: Restore cache
         uses: actions/cache@v4
         with:
@@ -52,9 +57,17 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.os }}-zig-
 
       - name: Run Tests in memory
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: zig build test -Dci=true -Din_memory=true --summary all -fqemu -fwine
+      - name: Run Tests in memory
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: zig build test -Dci=true -Din_memory=true --summary all -frosetta
+      - name: Run Tests in memory
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: zig build test -Dci=true -Din_memory=true --summary all
 
       - name: Build the example zigcrypto loadable extension
         run: zig build zigcrypto
       - name: Test the zigcrypto loadable extension
+        if: ${{ matrix.os != 'windows-latest' }}
         run: ./zig-out/bin/zigcrypto-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.os }}-zig-
 
       - name: Run Tests in memory
-        run: zig build test -Dci=true -Din_memory=true --summary all
+        run: zig build test -Dci=true -Din_memory=true --summary all -fqemu -fwine
 
       - name: Build the example zigcrypto loadable extension
         run: zig build zigcrypto

--- a/build.zig
+++ b/build.zig
@@ -37,10 +37,6 @@ const ci_targets = switch (builtin.target.cpu.arch) {
         .linux => [_]TestTarget{
             // Targets linux but other CPU archs.
             TestTarget{
-                .query = .{},
-                .bundled = false,
-            },
-            TestTarget{
                 .query = .{
                     .cpu_arch = .x86_64,
                     .abi = .musl,

--- a/build.zig
+++ b/build.zig
@@ -35,66 +35,21 @@ const TestTarget = struct {
 const ci_targets = switch (builtin.target.cpu.arch) {
     .x86_64 => switch (builtin.target.os.tag) {
         .linux => [_]TestTarget{
-            // Targets linux but other CPU archs.
-            TestTarget{
-                .query = .{
-                    .cpu_arch = .x86_64,
-                    .abi = .musl,
-                },
-                .bundled = true,
-            },
-            TestTarget{
-                .query = .{
-                    .cpu_arch = .x86,
-                    .abi = .musl,
-                },
-                .bundled = true,
-            },
+            TestTarget{ .query = .{ .cpu_arch = .x86_64, .abi = .musl }, .bundled = true },
+            TestTarget{ .query = .{ .cpu_arch = .x86, .abi = .musl }, .bundled = true },
+            TestTarget{ .query = .{ .cpu_arch = .aarch64, .abi = .musl }, .bundled = true },
         },
         .windows => [_]TestTarget{
-            TestTarget{
-                .query = .{
-                    .cpu_arch = .x86_64,
-                    .abi = .gnu,
-                },
-                .bundled = true,
-            },
-            TestTarget{
-                .query = .{
-                    .cpu_arch = .x86,
-                    .abi = .gnu,
-                },
-                .bundled = true,
-            },
+            TestTarget{ .query = .{ .cpu_arch = .x86_64, .abi = .gnu }, .bundled = true },
+            TestTarget{ .query = .{ .cpu_arch = .x86, .abi = .gnu }, .bundled = true },
         },
         .macos => [_]TestTarget{
-            TestTarget{
-                .query = .{
-                    .cpu_arch = .x86_64,
-                },
-                .bundled = true,
-            },
-            // TODO(vincent): this fails for some reason
-            // TestTarget{
-            //     .query =.{
-            //         .cpu_arch = .aarch64,
-            //     },
-            //     .bundled = true,
-            // },
+            TestTarget{ .query = .{ .cpu_arch = .x86_64 }, .bundled = true },
+            TestTarget{ .query = .{ .cpu_arch = .aarch64 }, .bundled = true },
         },
-        else => [_]TestTarget{
-            TestTarget{
-                .query = .{},
-                .bundled = false,
-            },
-        },
+        else => unreachable,
     },
-    else => [_]TestTarget{
-        TestTarget{
-            .query = .{},
-            .bundled = false,
-        },
-    },
+    else => unreachable,
 };
 
 const all_test_targets = switch (builtin.target.cpu.arch) {

--- a/build.zig
+++ b/build.zig
@@ -267,6 +267,8 @@ pub fn build(b: *std.Build) !void {
     const target = b.resolveTargetQuery(query);
     const optimize = b.standardOptimizeOption(.{});
 
+    const c_flags = &[_][]const u8{"-std=c99"};
+
     const sqlite_lib = b.addStaticLibrary(.{
         .name = "sqlite",
         .target = target,
@@ -274,9 +276,12 @@ pub fn build(b: *std.Build) !void {
     });
 
     sqlite_lib.addIncludePath(.{ .path = "c/" });
-    sqlite_lib.addCSourceFile(.{
-        .file = .{ .path = "c/sqlite3.c" },
-        .flags = &[_][]const u8{"-std=c99"},
+    sqlite_lib.addCSourceFiles(.{
+        .files = &[_][]const u8{
+            "c/sqlite3.c",
+            "c/workaround.c",
+        },
+        .flags = c_flags,
     });
     sqlite_lib.linkLibC();
     sqlite_lib.installHeader(.{ .path = "c/sqlite3.h" }, "sqlite3.h");
@@ -345,9 +350,12 @@ pub fn build(b: *std.Build) !void {
                 .target = cross_target,
                 .optimize = optimize,
             });
-            lib.addCSourceFile(.{
-                .file = .{ .path = "c/sqlite3.c" },
-                .flags = &[_][]const u8{"-std=c99"},
+            lib.addCSourceFiles(.{
+                .files = &[_][]const u8{
+                    "c/sqlite3.c",
+                    "c/workaround.c",
+                },
+                .flags = c_flags,
             });
             lib.linkLibC();
             sqlite3 = lib;
@@ -362,6 +370,7 @@ pub fn build(b: *std.Build) !void {
             .target = cross_target,
             .optimize = optimize,
         });
+        lib.addCSourceFile(.{ .file = .{ .path = "c/workaround.c" }, .flags = c_flags });
         if (bundled) lib.addIncludePath(.{ .path = "c" });
         linkSqlite(lib);
 
@@ -381,10 +390,7 @@ pub fn build(b: *std.Build) !void {
         .target = getTarget(target, true),
         .optimize = optimize,
     });
-    lib.addCSourceFile(.{
-        .file = .{ .path = "c/sqlite3.c" },
-        .flags = &[_][]const u8{"-std=c99"},
-    });
+    lib.addCSourceFile(.{ .file = .{ .path = "c/sqlite3.c" }, .flags = c_flags });
     lib.addIncludePath(.{ .path = "c" });
     lib.linkLibC();
 

--- a/c.zig
+++ b/c.zig
@@ -5,6 +5,7 @@ pub const c = if (@hasDecl(root, "loadable_extension"))
 else
     @cImport({
         @cInclude("sqlite3.h");
+        @cInclude("workaround.h");
     });
 
 // versionGreaterThanOrEqualTo returns true if the SQLite version is >= to the major.minor.patch provided.

--- a/c/loadable_extension.zig
+++ b/c/loadable_extension.zig
@@ -1,5 +1,6 @@
 const c = @cImport({
     @cInclude("loadable-ext-sqlite3ext.h");
+    @cInclude("workaround.h");
 });
 
 pub usingnamespace c;

--- a/c/workaround.c
+++ b/c/workaround.c
@@ -1,0 +1,5 @@
+#include "workaround.h"
+
+my_sqlite3_destructor_type sqliteTransientAsDestructor() {
+  return (my_sqlite3_destructor_type)-1;
+}

--- a/c/workaround.h
+++ b/c/workaround.h
@@ -1,0 +1,3 @@
+typedef void (*my_sqlite3_destructor_type)(void *);
+
+my_sqlite3_destructor_type sqliteTransientAsDestructor();

--- a/helpers.zig
+++ b/helpers.zig
@@ -13,8 +13,8 @@ pub fn setResult(ctx: ?*c.sqlite3_context, result: anytype) void {
     const ResultType = @TypeOf(result);
 
     switch (ResultType) {
-        Text => c.sqlite3_result_text(ctx, result.data.ptr, @intCast(result.data.len), c.SQLITE_TRANSIENT),
-        Blob => c.sqlite3_result_blob(ctx, result.data.ptr, @intCast(result.data.len), c.SQLITE_TRANSIENT),
+        Text => c.sqlite3_result_text(ctx, result.data.ptr, @intCast(result.data.len), c.sqliteTransientAsDestructor()),
+        Blob => c.sqlite3_result_blob(ctx, result.data.ptr, @intCast(result.data.len), c.sqliteTransientAsDestructor()),
         else => switch (@typeInfo(ResultType)) {
             .Int => |info| if ((info.bits + if (info.signedness == .unsigned) 1 else 0) <= 32) {
                 c.sqlite3_result_int(ctx, result);
@@ -26,12 +26,12 @@ pub fn setResult(ctx: ?*c.sqlite3_context, result: anytype) void {
             .Float => c.sqlite3_result_double(ctx, result),
             .Bool => c.sqlite3_result_int(ctx, if (result) 1 else 0),
             .Array => |arr| switch (arr.child) {
-                u8 => c.sqlite3_result_blob(ctx, &result, arr.len, c.SQLITE_TRANSIENT),
+                u8 => c.sqlite3_result_blob(ctx, &result, arr.len, c.sqliteTransientAsDestructor()),
                 else => @compileError("cannot use a result of type " ++ @typeName(ResultType)),
             },
             .Pointer => |ptr| switch (ptr.size) {
                 .Slice => switch (ptr.child) {
-                    u8 => c.sqlite3_result_text(ctx, result.ptr, @intCast(result.len), c.SQLITE_TRANSIENT),
+                    u8 => c.sqlite3_result_text(ctx, result.ptr, @intCast(result.len), c.sqliteTransientAsDestructor()),
                     else => @compileError("cannot use a result of type " ++ @typeName(ResultType)),
                 },
                 else => @compileError("cannot use a result of type " ++ @typeName(ResultType)),

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1676,7 +1676,7 @@ pub const DynamicStatement = struct {
                         const data: []const u8 = field[0..field.len];
 
                         // NOTE(vincent): The array is temporary and must be copied, therefore we use SQLITE_TRANSIENT
-                        const result = c.sqlite3_bind_text(self.stmt, column, data.ptr, @intCast(data.len), c.SQLITE_TRANSIENT);
+                        const result = c.sqlite3_bind_text(self.stmt, column, data.ptr, @intCast(data.len), c.sqliteTransientAsDestructor());
                         return convertResultToError(result);
                     },
                     else => @compileError("cannot bind field " ++ field_name ++ " of type array of " ++ @typeName(arr.child)),


### PR DESCRIPTION
# Description

On some architectures `SQLITE_TRANSIENT` is translated in such a way that it fails to compile, see https://github.com/ziglang/zig/issues/15893

This PR works around this problem by using a C function to return the proper destructor type.