### PR TITLE
Enable features without vendoring

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -3743,7 +3743,7 @@ test "sqlite: create aggregate function with no aggregate context" {
     var db = try getTestDb();
     defer db.deinit();
 
-    var rand = std.rand.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
+    var rand = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
 
     // Create an aggregate function working with a MyContext
 
@@ -3804,7 +3804,7 @@ test "sqlite: create aggregate function with an aggregate context" {
     var db = try getTestDb();
     defer db.deinit();
 
-    var rand = std.rand.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
+    var rand = std.Random.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
 
     try db.createAggregateFunction(
         "mySum",

--- a/vtab.zig
+++ b/vtab.zig
@@ -1026,7 +1026,7 @@ const TestVirtualTable = struct {
                 "Vincent", "José", "Michel",
             };
 
-            var rand = std.rand.DefaultPrng.init(204882485);
+            var rand = std.Random.DefaultPrng.init(204882485);
 
             const tmp = try allocator.alloc(Row, n);
             for (tmp) |*s| {


### PR DESCRIPTION
# Description

This PR adds the ability to enable SQLite features (at this point only `fts5`) via build system options and in doing so allows customising SQLite features without resorting to vendoring (as per https://github.com/vrischmann/zig-sqlite?tab=readme-ov-file#using-the-bundled-sqlite-source-code-file).

This means for example you can take the example of installation via the official package manager (https://github.com/vrischmann/zig-sqlite?tab=readme-ov-file#official-package-manager) and simply add, e.g., `.fts5 = true` to the options to enable full text search:

```zig
const sqlite = b.dependency("sqlite", .{
    .target = target,
    .optimize = optimize,
    .fts5 = true,
});

exe.root_module.addImport("sqlite", sqlite.module("sqlite"));

// links the bundled sqlite3, so leave this out if you link the system one
exe.linkLibrary(sqlite.artifact("sqlite"));
```

A `EnableOptions` `struct` is added enumerating boolean options and instead of a static array with only `-std=c99` as an option, we make the flags an `ArrayList` with the same initial content but use a comptime `inline for` to iterate over each field of `EnableOptions` to create a `b.option` and add to the `flags` `ArrayList` when the given flag has been enabled. As reference this is the approach taken in https://github.com/mitchellh/zig-build-libxml2/blob/main/build.zig.

As it stands this PR makes it easy to any `SQLITE_ENABLE_*` options by adding to the `EnableOptions` `struct`. This could be expanded to handle other options and indeed non-boolean options.

Also updates `std.rand` -> `std.Random` as introduced in recent zig `master`.