### PR TITLE
fixup README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,9 @@ const row = try stmt.one(
     .{ .id = 20 },
 );
 if (row) |r| {
-    std.log.debug("name: {}, age: {}", .{std.mem.span((&row.name).ptr), row.age});
+    const name_ptr: [*:0]const u8 = &r.name;
+    std.log.debug("name: {s}, age: {}", .{ std.mem.span(name_ptr), r.age });
+}
 }
 ```
 Notice that to read text we need to use a 0-terminated array; if the `name` column is bigger than 127 bytes the call to `one` will fail.

--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ const row = try stmt.one(
     .{},
     .{ .id = 20 },
 );
-if (row) |row| {
-    std.log.debug("name: {}, age: {}", .{std.mem.spanZ(&row.name), row.age});
+if (row) |r| {
+    std.log.debug("name: {}, age: {}", .{std.mem.span((&row.name).ptr), row.age});
 }
 ```
 Notice that to read text we need to use a 0-terminated array; if the `name` column is bigger than 127 bytes the call to `one` will fail.


### PR DESCRIPTION
# Description
Hello there, Really nice repo you got here. I'm just tweaking some documentation here. 
I am running zig version `0.14.0-dev.2051+b1361f237`.
Which is ahead of 0.13, but you would also be able to do my method here on 0.13 as well. So I think my pr is valid.
## Documentation update
`std.mem.spanZ` is no longer in the standard. Found an alternate way to run the example. Updating readme for the next guy. 
Just a 2 line change to the README.md. 