### PR TITLE
Fix latest zig

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1568,6 +1568,10 @@ pub const DynamicStatement = struct {
     pub const PrepareError = error{EmptyQuery} || Error;
 
     fn prepare(db: *Db, query: []const u8, options: QueryOptions, flags: c_uint) PrepareError!Self {
+        return prepareWithTail(db, query, options, flags, null);
+    }
+
+    fn prepareWithTail(db: *Db, query: []const u8, options: QueryOptions, flags: c_uint, tail: ?*[*c]const u8) PrepareError!Self {
         var dummy_diags = Diagnostics{};
         var diags = options.diags orelse &dummy_diags;
         const stmt = blk: {
@@ -1578,7 +1582,7 @@ pub const DynamicStatement = struct {
                 @intCast(query.len),
                 flags,
                 &tmp,
-                options.sql_tail_ptr,
+                tail,
             );
             if (result != c.SQLITE_OK) {
                 diags.err = getLastDetailedErrorFromDb(db.db);

--- a/vtab.zig
+++ b/vtab.zig
@@ -32,7 +32,7 @@ pub const ModuleContext = struct {
     allocator: mem.Allocator,
 };
 
-fn dupeToSQLiteString(s: []const u8) [*c]const u8 {
+fn dupeToSQLiteString(s: []const u8) [*c]u8 {
     var buffer: [*c]u8 = @ptrCast(c.sqlite3_malloc(@intCast(s.len + 1)));
 
     mem.copyForwards(u8, buffer[0..s.len], s);
@@ -730,7 +730,7 @@ pub fn VirtualTable(
             return c.SQLITE_ERROR;
         }
 
-        fn xConnect(db: ?*c.sqlite3, module_context_ptr: ?*anyopaque, argc: c_int, argv: [*c]const [*c]const u8, vtab: [*c][*c]c.sqlite3_vtab, err_str: [*c][*c]const u8) callconv(.C) c_int {
+        fn xConnect(db: ?*c.sqlite3, module_context_ptr: ?*anyopaque, argc: c_int, argv: [*c]const [*c]const u8, vtab: [*c][*c]c.sqlite3_vtab, err_str: [*c][*c]u8) callconv(.C) c_int {
             const module_context = getModuleContext(module_context_ptr);
 
             var arena = heap.ArenaAllocator.init(module_context.allocator);


### PR DESCRIPTION
# Description

A recent master version of Zig broke things in the C translated code for sqlite, specifically in the pointer to the tail of the query in `sqlite3_prepare_v3`.

Instead of just fixing it somehow I decided to rework `execMulti` (which is the only code that needs the tail pointer) because I wasn't happy with exposing that awful raw C-pointer type to the user in `QueryOptions`.

Now we keep the tail pointer local to `execMulti`.