### PR TITLE
Update some missed Int -> int

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1463,7 +1463,7 @@ pub fn Iterator(comptime Type: type) type {
 
                             return std.meta.stringToEnum(FieldType, inner_value) orelse FieldType.default;
                         }
-                        if (@typeInfo(FieldType.BaseType) == .Int) {
+                        if (@typeInfo(FieldType.BaseType) == .int) {
                             return @enumFromInt(@as(TI.tag_type, @intCast(inner_value)));
                         }
                         @compileError("enum column " ++ @typeName(FieldType) ++ " must have a BaseType of either string or int");
@@ -1680,7 +1680,7 @@ pub const DynamicStatement = struct {
                 .@"enum" => {
                     if (comptime isZigString(FieldType.BaseType)) {
                         try self.bindField(FieldType.BaseType, options, field_name, i, @tagName(field));
-                    } else if (@typeInfo(FieldType.BaseType) == .Int) {
+                    } else if (@typeInfo(FieldType.BaseType) == .int) {
                         try self.bindField(FieldType.BaseType, options, field_name, i, @intFromEnum(field));
                     } else {
                         @compileError("enum column " ++ @typeName(FieldType) ++ " must have a BaseType of either string or int to bind");


### PR DESCRIPTION
# Description

Resolves this compilation error hit when updating a 0.13 project to master. (No further testing was done as there are other issues in my project preventing successful compilation on master.)
```
/Users/matthias/.cache/zig/p/12204ecfb22b7109dd3400cbdae8885e31fc653f33424bf35fe5fa21ceeadc90fcf8/sqlite.zig:1683:66: error: no field named 'Int' in enum '@typeInfo(builtin.Type).@"union".tag_type.?'
                    } else if (@typeInfo(FieldType.BaseType) == .Int) {
                                                                ~^~~
/Users/matthias/bin/lib/std/builtin.zig:557:18: note: enum declared here
pub const Type = union(enum) {
                 ^~~~~

```
