### PR TITLE
zig.mod: needs workaround.c

### DIFF
--- a/zig.mod
+++ b/zig.mod
@@ -7,4 +7,5 @@ c_include_dirs:
   - c
 c_source_files:
   - c/sqlite3.c
+  - c/workaround.c
 dependencies:


### PR DESCRIPTION
finally getting around to updating https://github.com/nektro/zig-zorm to 0.13 (i know 😅) and got the following error before applying this patch:

```
error: ld.lld: undefined symbol: sqliteTransientAsDestructor
    note: referenced by sqlite.zig:1679 (/home/meghan/dev/.zigmod/deps/git/github.com/vrischmann/zig-sqlite/sqlite.zig:1679)
    note:               /home/meghan/zig-cache/o/af79a354004d379e876ff5cb8d995080/test.o:(sqlite.DynamicStatement.bindField__anon_7594)
```
