### PR TITLE
zig.mod: fix http dep

### DIFF
--- a/zig.mod
+++ b/zig.mod
@@ -6,7 +6,6 @@ description: Thin SQLite wrapper
 c_include_dirs:
   - c
 c_source_files:
-  - c/sqlite3.c
   - c/workaround.c
 dependencies:
 - src: http https://sqlite.org/2025/sqlite-amalgamation-3480000.zip sha256-d9a15a42db7c78f88fe3d3c5945acce2f4bfe9e4da9f685cd19f6ea1d40aa884

--- a/zig.mod
+++ b/zig.mod
@@ -9,7 +9,7 @@ c_source_files:
   - c/sqlite3.c
   - c/workaround.c
 dependencies:
-- src: https://sqlite.org/2025/sqlite-amalgamation-3480000.zip
+- src: http https://sqlite.org/2025/sqlite-amalgamation-3480000.zip sha256-d9a15a42db7c78f88fe3d3c5945acce2f4bfe9e4da9f685cd19f6ea1d40aa884
   c_include_dirs:
     - sqlite-amalgamation-3480000
   c_source_files:


### PR DESCRIPTION
the `http` part is required
the `sha256-` part isnt strictly necessary but helps with caching
generated the hash with `curl -s https://sqlite.org/2025/sqlite-amalgamation-3480000.zip | sha256sum`
