### PR TITLE
Update to zig 0.15

### DIFF
--- a/build/Preprocessor.zig
+++ b/build/Preprocessor.zig
@@ -27,10 +27,10 @@ const mem = std.mem;
 fn readOriginalData(allocator: mem.Allocator, path: []const u8) ![]const u8 {
     var file = try std.fs.cwd().openFile(path, .{});
     defer file.close();
+    var buf: [1024]u8 = undefined;
+    var reader = file.reader(&buf);
 
-    var reader = file.reader();
-
-    const data = reader.readAllAlloc(allocator, 1024 * 1024);
+    const data = reader.interface.readAlloc(allocator, 1024 * 1024);
     return data;
 }
 
@@ -127,13 +127,13 @@ const Processor = struct {
             switch (range) {
                 .delete => |dr| {
                     const to_write = self.data[pos..dr.start];
-                    try writer.writeAll(to_write);
+                    try writer.interface.writeAll(to_write);
                     pos = dr.end;
                 },
                 .replace => |rr| {
                     const to_write = self.data[pos..rr.start];
-                    try writer.writeAll(to_write);
-                    try writer.writeAll(rr.replacement);
+                    try writer.interface.writeAll(to_write);
+                    try writer.interface.writeAll(rr.replacement);
                     pos = rr.end;
                 },
             }
@@ -148,7 +148,7 @@ const Processor = struct {
         // Finally append the remaining data in the buffer (the last range will probably not be the end of the file)
         if (pos < self.data.len) {
             const remaining_data = self.data[pos..];
-            try writer.writeAll(remaining_data);
+            try writer.interface.writeAll(remaining_data);
         }
     }
 };
@@ -196,7 +196,9 @@ pub fn sqlite3(allocator: mem.Allocator, input_path: []const u8, output_path: []
     defer output_file.close();
 
     try output_file.writeAll("/* sqlite3.h edited by the zig-sqlite build script */\n");
-    try processor.dump(output_file.writer());
+    var buf: [1024]u8 = undefined;
+    var out_writer = output_file.writer(&buf);
+    try processor.dump(&out_writer);
 }
 
 pub fn sqlite3ext(allocator: mem.Allocator, input_path: []const u8, output_path: []const u8) !void {
@@ -232,5 +234,7 @@ pub fn sqlite3ext(allocator: mem.Allocator, input_path: []const u8, output_path:
     defer output_file.close();
 
     try output_file.writeAll("/* sqlite3ext.h edited by the zig-sqlite build script */\n");
-    try processor.dump(output_file.writer());
+    var buf: [1024]u8 = undefined;
+    var out_writer = output_file.writer(&buf);
+    try processor.dump(&out_writer);
 }

--- a/c/loadable_extension.zig
+++ b/c/loadable_extension.zig
@@ -1,9 +1,7 @@
-const c = @cImport({
+pub const c = @cImport({
     @cInclude("loadable-ext-sqlite3ext.h");
     @cInclude("workaround.h");
 });
-
-pub usingnamespace c;
 
 pub var sqlite3_api: [*c]c.sqlite3_api_routines = null;
 
@@ -23,16 +21,16 @@ pub const sqlite3_uri_vsnprintf = @compileError("sqlite3_uri_vsnprintf can't be 
 pub const sqlite3_str_appendf = @compileError("sqlite3_str_appendf can't be implemented in Zig");
 pub const sqlite3_str_vappendf = @compileError("sqlite3_str_vappendf can't be implemented in Zig");
 
-pub export fn sqlite3_aggregate_context(p: ?*c.sqlite3_context, nBytes: c_int) callconv(.C) ?*anyopaque {
+pub export fn sqlite3_aggregate_context(p: ?*c.sqlite3_context, nBytes: c_int) callconv(.c) ?*anyopaque {
     return sqlite3_api.*.aggregate_context.?(p, nBytes);
 }
-pub export fn sqlite3_bind_blob(pStmt: ?*c.sqlite3_stmt, i: c_int, zData: ?*const anyopaque, nData: c_int, xDel: ?*const fn (?*anyopaque) callconv(.C) void) c_int {
+pub export fn sqlite3_bind_blob(pStmt: ?*c.sqlite3_stmt, i: c_int, zData: ?*const anyopaque, nData: c_int, xDel: ?*const fn (?*anyopaque) callconv(.c) void) c_int {
     return sqlite3_api.*.bind_blob.?(pStmt, i, zData, nData, xDel);
 }
-pub export fn sqlite3_bind_double(pStmt: ?*c.sqlite3_stmt, i: c_int, rValue: f64) callconv(.C) c_int {
+pub export fn sqlite3_bind_double(pStmt: ?*c.sqlite3_stmt, i: c_int, rValue: f64) callconv(.c) c_int {
     return sqlite3_api.*.bind_double.?(pStmt, i, rValue);
 }
-pub export fn sqlite3_bind_int(pStmt: ?*c.sqlite3_stmt, i: c_int, iValue: c_int) callconv(.C) c_int {
+pub export fn sqlite3_bind_int(pStmt: ?*c.sqlite3_stmt, i: c_int, iValue: c_int) callconv(.c) c_int {
     return sqlite3_api.*.bind_int.?(pStmt, i, iValue);
 }
 pub export fn sqlite3_bind_int64(pStmt: ?*c.sqlite3_stmt, i: c_int, iValue: c.sqlite3_int64) c_int {
@@ -50,16 +48,16 @@ pub export fn sqlite3_bind_parameter_index(pStmt: ?*c.sqlite3_stmt, zName: [*c]c
 pub export fn sqlite3_bind_parameter_name(pStmt: ?*c.sqlite3_stmt, i: c_int) [*c]const u8 {
     return sqlite3_api.*.bind_parameter_name.?(pStmt, i);
 }
-pub export fn sqlite3_bind_text(pStmt: ?*c.sqlite3_stmt, i: c_int, zData: [*c]const u8, nData: c_int, xDel: ?*const fn (?*anyopaque) callconv(.C) void) c_int {
+pub export fn sqlite3_bind_text(pStmt: ?*c.sqlite3_stmt, i: c_int, zData: [*c]const u8, nData: c_int, xDel: ?*const fn (?*anyopaque) callconv(.c) void) c_int {
     return sqlite3_api.*.bind_text.?(pStmt, i, zData, nData, xDel);
 }
-pub export fn sqlite3_bind_text16(pStmt: ?*c.sqlite3_stmt, i: c_int, zData: ?*const anyopaque, nData: c_int, xDel: ?*const fn (?*anyopaque) callconv(.C) void) c_int {
+pub export fn sqlite3_bind_text16(pStmt: ?*c.sqlite3_stmt, i: c_int, zData: ?*const anyopaque, nData: c_int, xDel: ?*const fn (?*anyopaque) callconv(.c) void) c_int {
     return sqlite3_api.*.bind_text16.?(pStmt, i, zData, nData, xDel);
 }
 pub export fn sqlite3_bind_value(pStmt: ?*c.sqlite3_stmt, i: c_int, pValue: ?*const c.sqlite3_value) c_int {
     return sqlite3_api.*.bind_value.?(pStmt, i, pValue);
 }
-pub export fn sqlite3_busy_handler(db: ?*c.sqlite3, xBusy: ?*const fn (?*anyopaque, c_int) callconv(.C) c_int, pArg: ?*anyopaque) c_int {
+pub export fn sqlite3_busy_handler(db: ?*c.sqlite3, xBusy: ?*const fn (?*anyopaque, c_int) callconv(.c) c_int, pArg: ?*anyopaque) c_int {
     return sqlite3_api.*.busy_handler.?(db, xBusy, pArg);
 }
 pub export fn sqlite3_busy_timeout(db: ?*c.sqlite3, ms: c_int) c_int {
@@ -71,10 +69,10 @@ pub export fn sqlite3_changes(db: ?*c.sqlite3) c_int {
 pub export fn sqlite3_close(db: ?*c.sqlite3) c_int {
     return sqlite3_api.*.close.?(db);
 }
-pub export fn sqlite3_collation_needed(db: ?*c.sqlite3, pCollNeededArg: ?*anyopaque, xCollNeeded: ?*const fn (?*anyopaque, ?*c.sqlite3, c_int, [*c]const u8) callconv(.C) void) c_int {
+pub export fn sqlite3_collation_needed(db: ?*c.sqlite3, pCollNeededArg: ?*anyopaque, xCollNeeded: ?*const fn (?*anyopaque, ?*c.sqlite3, c_int, [*c]const u8) callconv(.c) void) c_int {
     return sqlite3_api.*.collation_needed.?(db, pCollNeededArg, xCollNeeded);
 }
-pub export fn sqlite3_collation_needed16(db: ?*c.sqlite3, pCollNeededArg: ?*anyopaque, xCollNeeded16: ?*const fn (?*anyopaque, ?*c.sqlite3, c_int, ?*const anyopaque) callconv(.C) void) c_int {
+pub export fn sqlite3_collation_needed16(db: ?*c.sqlite3, pCollNeededArg: ?*anyopaque, xCollNeeded16: ?*const fn (?*anyopaque, ?*c.sqlite3, c_int, ?*const anyopaque) callconv(.c) void) c_int {
     return sqlite3_api.*.collation_needed16.?(db, pCollNeededArg, xCollNeeded16);
 }
 pub export fn sqlite3_column_blob(pStmt: ?*c.sqlite3_stmt, iCol: c_int) ?*const anyopaque {
@@ -140,7 +138,7 @@ pub export fn sqlite3_column_type(pStmt: ?*c.sqlite3_stmt, iCol: c_int) c_int {
 pub export fn sqlite3_column_value(pStmt: ?*c.sqlite3_stmt, iCol: c_int) ?*c.sqlite3_value {
     return sqlite3_api.*.column_value.?(pStmt, iCol);
 }
-pub export fn sqlite3_commit_hook(db: ?*c.sqlite3, xCallback: ?*const fn (?*anyopaque) callconv(.C) c_int, pArg: ?*anyopaque) ?*anyopaque {
+pub export fn sqlite3_commit_hook(db: ?*c.sqlite3, xCallback: ?*const fn (?*anyopaque) callconv(.c) c_int, pArg: ?*anyopaque) ?*anyopaque {
     return sqlite3_api.*.commit_hook.?(db, xCallback, pArg);
 }
 pub export fn sqlite3_complete(sql: [*c]const u8) c_int {
@@ -149,22 +147,22 @@ pub export fn sqlite3_complete(sql: [*c]const u8) c_int {
 pub export fn sqlite3_complete16(sql: ?*const anyopaque) c_int {
     return sqlite3_api.*.complete16.?(sql);
 }
-pub export fn sqlite3_create_collation(db: ?*c.sqlite3, zName: [*c]const u8, eTextRep: c_int, pArg: ?*anyopaque, xCompare: ?*const fn (?*anyopaque, c_int, ?*const anyopaque, c_int, ?*const anyopaque) callconv(.C) c_int) c_int {
+pub export fn sqlite3_create_collation(db: ?*c.sqlite3, zName: [*c]const u8, eTextRep: c_int, pArg: ?*anyopaque, xCompare: ?*const fn (?*anyopaque, c_int, ?*const anyopaque, c_int, ?*const anyopaque) callconv(.c) c_int) c_int {
     return sqlite3_api.*.create_collation.?(db, zName, eTextRep, pArg, xCompare);
 }
-pub export fn sqlite3_create_collation16(db: ?*c.sqlite3, zName: ?*const anyopaque, eTextRep: c_int, pArg: ?*anyopaque, xCompare: ?*const fn (?*anyopaque, c_int, ?*const anyopaque, c_int, ?*const anyopaque) callconv(.C) c_int) c_int {
+pub export fn sqlite3_create_collation16(db: ?*c.sqlite3, zName: ?*const anyopaque, eTextRep: c_int, pArg: ?*anyopaque, xCompare: ?*const fn (?*anyopaque, c_int, ?*const anyopaque, c_int, ?*const anyopaque) callconv(.c) c_int) c_int {
     return sqlite3_api.*.create_collation16.?(db, zName, eTextRep, pArg, xCompare);
 }
-pub export fn sqlite3_create_function(db: ?*c.sqlite3, zFunctionName: [*c]const u8, nArg: c_int, eTextRep: c_int, pApp: ?*anyopaque, xFunc: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.C) void, xStep: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.C) void, xFinal: ?*const fn (?*c.sqlite3_context) callconv(.C) void) c_int {
+pub export fn sqlite3_create_function(db: ?*c.sqlite3, zFunctionName: [*c]const u8, nArg: c_int, eTextRep: c_int, pApp: ?*anyopaque, xFunc: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.c) void, xStep: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.c) void, xFinal: ?*const fn (?*c.sqlite3_context) callconv(.c) void) c_int {
     return sqlite3_api.*.create_function.?(db, zFunctionName, nArg, eTextRep, pApp, xFunc, xStep, xFinal);
 }
-pub export fn sqlite3_create_function16(db: ?*c.sqlite3, zFunctionName: ?*const anyopaque, nArg: c_int, eTextRep: c_int, pApp: ?*anyopaque, xFunc: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.C) void, xStep: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.C) void, xFinal: ?*const fn (?*c.sqlite3_context) callconv(.C) void) c_int {
+pub export fn sqlite3_create_function16(db: ?*c.sqlite3, zFunctionName: ?*const anyopaque, nArg: c_int, eTextRep: c_int, pApp: ?*anyopaque, xFunc: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.c) void, xStep: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.c) void, xFinal: ?*const fn (?*c.sqlite3_context) callconv(.c) void) c_int {
     return sqlite3_api.*.create_function16.?(db, zFunctionName, nArg, eTextRep, pApp, xFunc, xStep, xFinal);
 }
 pub export fn sqlite3_create_module(db: ?*c.sqlite3, zName: [*c]const u8, pModule: [*c]const c.sqlite3_module, pAux: ?*anyopaque) c_int {
     return sqlite3_api.*.create_module.?(db, zName, pModule, pAux);
 }
-pub export fn sqlite3_create_module_v2(db: ?*c.sqlite3, zName: [*c]const u8, pModule: [*c]const c.sqlite3_module, pAux: ?*anyopaque, xDestroy: ?*const fn (?*anyopaque) callconv(.C) void) c_int {
+pub export fn sqlite3_create_module_v2(db: ?*c.sqlite3, zName: [*c]const u8, pModule: [*c]const c.sqlite3_module, pAux: ?*anyopaque, xDestroy: ?*const fn (?*anyopaque) callconv(.c) void) c_int {
     return sqlite3_api.*.create_module_v2.?(db, zName, pModule, pAux, xDestroy);
 }
 pub export fn sqlite3_data_count(pStmt: ?*c.sqlite3_stmt) c_int {
@@ -189,7 +187,7 @@ pub export fn sqlite3_errmsg(db: ?*c.sqlite3) [*c]const u8 {
 pub export fn sqlite3_errmsg16(db: ?*c.sqlite3) ?*const anyopaque {
     return sqlite3_api.*.errmsg16.?(db);
 }
-pub export fn sqlite3_exec(db: ?*c.sqlite3, zSql: [*c]const u8, xCallback: ?*const fn (?*anyopaque, c_int, [*c][*c]u8, [*c][*c]u8) callconv(.C) c_int, pArg: ?*anyopaque, pzErrMsg: [*c][*c]u8) c_int {
+pub export fn sqlite3_exec(db: ?*c.sqlite3, zSql: [*c]const u8, xCallback: ?*const fn (?*anyopaque, c_int, [*c][*c]u8, [*c][*c]u8) callconv(.c) c_int, pArg: ?*anyopaque, pzErrMsg: [*c][*c]u8) c_int {
     return sqlite3_api.*.exec.?(db, zSql, xCallback, pArg, pzErrMsg);
 }
 pub export fn sqlite3_finalize(pStmt: ?*c.sqlite3_stmt) c_int {
@@ -216,7 +214,7 @@ pub export fn sqlite3_interrupt(db: ?*c.sqlite3) void {
 pub export fn sqlite3_last_insert_rowid(db: ?*c.sqlite3) c.sqlite3_int64 {
     return sqlite3_api.*.last_insert_rowid.?(db);
 }
-pub export fn sqlite3_libversion() callconv(.C) [*c]const u8 {
+pub export fn sqlite3_libversion() callconv(.c) [*c]const u8 {
     return sqlite3_api.*.libversion.?();
 }
 pub export fn sqlite3_libversion_number() c_int {
@@ -243,10 +241,10 @@ pub export fn sqlite3_prepare_v2(db: ?*c.sqlite3, zSql: [*c]const u8, nByte: c_i
 pub export fn sqlite3_prepare16_v2(db: ?*c.sqlite3, zSql: ?*const anyopaque, nByte: c_int, ppStmt: [*c]?*c.sqlite3_stmt, pzTail: [*c]?*const anyopaque) c_int {
     return sqlite3_api.*.prepare16_v2.?(db, zSql, nByte, ppStmt, pzTail);
 }
-pub export fn sqlite3_profile(db: ?*c.sqlite3, xProfile: ?*const fn (?*anyopaque, [*c]const u8, c.sqlite3_uint64) callconv(.C) void, pArg: ?*anyopaque) ?*anyopaque {
+pub export fn sqlite3_profile(db: ?*c.sqlite3, xProfile: ?*const fn (?*anyopaque, [*c]const u8, c.sqlite3_uint64) callconv(.c) void, pArg: ?*anyopaque) ?*anyopaque {
     return sqlite3_api.*.profile.?(db, xProfile, pArg);
 }
-pub export fn sqlite3_progress_handler(db: ?*c.sqlite3, nOps: c_int, xProgress: ?*const fn (?*anyopaque) callconv(.C) c_int, pArg: ?*anyopaque) void {
+pub export fn sqlite3_progress_handler(db: ?*c.sqlite3, nOps: c_int, xProgress: ?*const fn (?*anyopaque) callconv(.c) c_int, pArg: ?*anyopaque) void {
     return sqlite3_api.*.progress_handler.?(db, nOps, xProgress, pArg);
 }
 pub export fn sqlite3_realloc(pOld: ?*anyopaque, n: c_int) ?*anyopaque {
@@ -255,7 +253,7 @@ pub export fn sqlite3_realloc(pOld: ?*anyopaque, n: c_int) ?*anyopaque {
 pub export fn sqlite3_reset(pStmt: ?*c.sqlite3_stmt) c_int {
     return sqlite3_api.*.reset.?(pStmt);
 }
-pub export fn sqlite3_result_blob(pCtx: ?*c.sqlite3_context, z: ?*const anyopaque, n: c_int, xDel: ?*const fn (?*anyopaque) callconv(.C) void) void {
+pub export fn sqlite3_result_blob(pCtx: ?*c.sqlite3_context, z: ?*const anyopaque, n: c_int, xDel: ?*const fn (?*anyopaque) callconv(.c) void) void {
     return sqlite3_api.*.result_blob.?(pCtx, z, n, xDel);
 }
 
@@ -278,28 +276,28 @@ pub export fn sqlite3_result_int64(pCtx: ?*c.sqlite3_context, iVal: c.sqlite3_in
 pub export fn sqlite3_result_null(pCtx: ?*c.sqlite3_context) void {
     return sqlite3_api.*.result_null.?(pCtx);
 }
-pub export fn sqlite3_result_text(pCtx: ?*c.sqlite3_context, z: [*c]const u8, n: c_int, xDel: ?*const fn (?*anyopaque) callconv(.C) void) void {
+pub export fn sqlite3_result_text(pCtx: ?*c.sqlite3_context, z: [*c]const u8, n: c_int, xDel: ?*const fn (?*anyopaque) callconv(.c) void) void {
     return sqlite3_api.*.result_text.?(pCtx, z, n, xDel);
 }
-pub export fn sqlite3_result_text16(pCtx: ?*c.sqlite3_context, z: ?*const anyopaque, n: c_int, xDel: ?*const fn (?*anyopaque) callconv(.C) void) void {
+pub export fn sqlite3_result_text16(pCtx: ?*c.sqlite3_context, z: ?*const anyopaque, n: c_int, xDel: ?*const fn (?*anyopaque) callconv(.c) void) void {
     return sqlite3_api.*.result_text16.?(pCtx, z, n, xDel);
 }
-pub export fn sqlite3_result_text16be(pCtx: ?*c.sqlite3_context, z: ?*const anyopaque, n: c_int, xDel: ?*const fn (?*anyopaque) callconv(.C) void) void {
+pub export fn sqlite3_result_text16be(pCtx: ?*c.sqlite3_context, z: ?*const anyopaque, n: c_int, xDel: ?*const fn (?*anyopaque) callconv(.c) void) void {
     return sqlite3_api.*.result_text16be.?(pCtx, z, n, xDel);
 }
-pub export fn sqlite3_result_text16le(pCtx: ?*c.sqlite3_context, z: ?*const anyopaque, n: c_int, xDel: ?*const fn (?*anyopaque) callconv(.C) void) void {
+pub export fn sqlite3_result_text16le(pCtx: ?*c.sqlite3_context, z: ?*const anyopaque, n: c_int, xDel: ?*const fn (?*anyopaque) callconv(.c) void) void {
     return sqlite3_api.*.result_text16le.?(pCtx, z, n, xDel);
 }
 pub export fn sqlite3_result_value(pCtx: ?*c.sqlite3_context, pValue: ?*c.sqlite3_value) void {
     return sqlite3_api.*.result_value.?(pCtx, pValue);
 }
-pub export fn sqlite3_rollback_hook(db: ?*c.sqlite3, xCallback: ?*const fn (?*anyopaque) callconv(.C) void, pArg: ?*anyopaque) ?*anyopaque {
+pub export fn sqlite3_rollback_hook(db: ?*c.sqlite3, xCallback: ?*const fn (?*anyopaque) callconv(.c) void, pArg: ?*anyopaque) ?*anyopaque {
     return sqlite3_api.*.rollback_hook.?(db, xCallback, pArg);
 }
-pub export fn sqlite3_set_authorizer(db: ?*c.sqlite3, xAuth: ?*const fn (?*anyopaque, c_int, [*c]const u8, [*c]const u8, [*c]const u8, [*c]const u8) callconv(.C) c_int, pArg: ?*anyopaque) c_int {
+pub export fn sqlite3_set_authorizer(db: ?*c.sqlite3, xAuth: ?*const fn (?*anyopaque, c_int, [*c]const u8, [*c]const u8, [*c]const u8, [*c]const u8) callconv(.c) c_int, pArg: ?*anyopaque) c_int {
     return sqlite3_api.*.set_authorizer.?(db, xAuth, pArg);
 }
-pub export fn sqlite3_set_auxdata(pCtx: ?*c.sqlite3_context, iArg: c_int, pAux: ?*anyopaque, xDelete: ?*const fn (?*anyopaque) callconv(.C) void) void {
+pub export fn sqlite3_set_auxdata(pCtx: ?*c.sqlite3_context, iArg: c_int, pAux: ?*anyopaque, xDelete: ?*const fn (?*anyopaque) callconv(.c) void) void {
     return sqlite3_api.*.set_auxdata.?(pCtx, iArg, pAux, xDelete);
 }
 pub export fn sqlite3_step(pStmt: ?*c.sqlite3_stmt) c_int {
@@ -314,10 +312,10 @@ pub export fn sqlite3_thread_cleanup() void {
 pub export fn sqlite3_total_changes(db: ?*c.sqlite3) c_int {
     return sqlite3_api.*.total_changes.?(db);
 }
-pub export fn sqlite3_trace(db: ?*c.sqlite3, xTrace: ?*const fn (?*anyopaque, [*c]const u8) callconv(.C) void, pArg: ?*anyopaque) ?*anyopaque {
+pub export fn sqlite3_trace(db: ?*c.sqlite3, xTrace: ?*const fn (?*anyopaque, [*c]const u8) callconv(.c) void, pArg: ?*anyopaque) ?*anyopaque {
     return sqlite3_api.*.trace.?(db, xTrace, pArg);
 }
-pub export fn sqlite3_update_hook(db: ?*c.sqlite3, xCallback: ?*const fn (?*anyopaque, c_int, [*c]const u8, [*c]const u8, c.sqlite3_int64) callconv(.C) void, pArg: ?*anyopaque) ?*anyopaque {
+pub export fn sqlite3_update_hook(db: ?*c.sqlite3, xCallback: ?*const fn (?*anyopaque, c_int, [*c]const u8, [*c]const u8, c.sqlite3_int64) callconv(.c) void, pArg: ?*anyopaque) ?*anyopaque {
     return sqlite3_api.*.update_hook.?(db, xCallback, pArg);
 }
 pub export fn sqlite3_user_data(pCtx: ?*c.sqlite3_context) ?*anyopaque {
@@ -383,7 +381,7 @@ pub export fn sqlite3_blob_read(pBlob: ?*c.sqlite3_blob, z: ?*anyopaque, n: c_in
 pub export fn sqlite3_blob_write(pBlob: ?*c.sqlite3_blob, z: ?*const anyopaque, n: c_int, iOffset: c_int) c_int {
     return sqlite3_api.*.blob_write.?(pBlob, z, n, iOffset);
 }
-pub export fn sqlite3_create_collation_v2(db: ?*c.sqlite3, zName: [*c]const u8, eTextRep: c_int, pCtx: ?*anyopaque, xCompare: ?*const fn (?*anyopaque, c_int, ?*const anyopaque, c_int, ?*const anyopaque) callconv(.C) c_int, xDel: ?*const fn (?*anyopaque) callconv(.C) void) c_int {
+pub export fn sqlite3_create_collation_v2(db: ?*c.sqlite3, zName: [*c]const u8, eTextRep: c_int, pCtx: ?*anyopaque, xCompare: ?*const fn (?*anyopaque, c_int, ?*const anyopaque, c_int, ?*const anyopaque) callconv(.c) c_int, xDel: ?*const fn (?*anyopaque) callconv(.c) void) c_int {
     return sqlite3_api.*.create_collation_v2.?(db, zName, eTextRep, pCtx, xCompare, xDel);
 }
 pub export fn sqlite3_file_control(db: ?*c.sqlite3, zDbName: [*c]const u8, op: c_int, pArg: ?*anyopaque) c_int {
@@ -494,10 +492,10 @@ pub export fn sqlite3_create_function_v2(
     nArg: c_int,
     eTextRep: c_int,
     pApp: ?*anyopaque,
-    xFunc: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.C) void,
-    xStep: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.C) void,
-    xFinal: ?*const fn (?*c.sqlite3_context) callconv(.C) void,
-    xDestroy: ?*const fn (?*anyopaque) callconv(.C) void,
+    xFunc: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.c) void,
+    xStep: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.c) void,
+    xFinal: ?*const fn (?*c.sqlite3_context) callconv(.c) void,
+    xDestroy: ?*const fn (?*anyopaque) callconv(.c) void,
 ) c_int {
     return sqlite3_api.*.create_function_v2.?(db, zFunctionName, nArg, eTextRep, pApp, xFunc, xStep, xFinal, xDestroy);
 }
@@ -522,7 +520,7 @@ pub export fn sqlite3_stmt_status(pStmt: ?*c.sqlite3_stmt, op: c_int, resetFlag:
 pub export fn sqlite3_strnicmp(zLeft: [*c]const u8, zRight: [*c]const u8, N: c_int) c_int {
     return sqlite3_api.*.strnicmp.?(zLeft, zRight, N);
 }
-pub export fn sqlite3_unlock_notify(pBlocked: ?*c.sqlite3, xNotify: ?*const fn ([*c]?*anyopaque, c_int) callconv(.C) void, pNotifyArg: ?*anyopaque) c_int {
+pub export fn sqlite3_unlock_notify(pBlocked: ?*c.sqlite3, xNotify: ?*const fn ([*c]?*anyopaque, c_int) callconv(.c) void, pNotifyArg: ?*anyopaque) c_int {
     return sqlite3_api.*.unlock_notify.?(pBlocked, xNotify, pNotifyArg);
 }
 pub export fn sqlite3_wal_autocheckpoint(db: ?*c.sqlite3, N: c_int) c_int {
@@ -531,7 +529,7 @@ pub export fn sqlite3_wal_autocheckpoint(db: ?*c.sqlite3, N: c_int) c_int {
 pub export fn sqlite3_wal_checkpoint(db: ?*c.sqlite3, zDb: [*c]const u8) c_int {
     return sqlite3_api.*.wal_checkpoint.?(db, zDb);
 }
-pub export fn sqlite3_wal_hook(db: ?*c.sqlite3, xCallback: ?*const fn (?*anyopaque, ?*c.sqlite3, [*c]const u8, c_int) callconv(.C) c_int, pArg: ?*anyopaque) ?*anyopaque {
+pub export fn sqlite3_wal_hook(db: ?*c.sqlite3, xCallback: ?*const fn (?*anyopaque, ?*c.sqlite3, [*c]const u8, c_int) callconv(.c) c_int, pArg: ?*anyopaque) ?*anyopaque {
     return sqlite3_api.*.wal_hook.?(db, xCallback, pArg);
 }
 pub export fn sqlite3_blob_reopen(pBlob: ?*c.sqlite3_blob, iRow: c.sqlite3_int64) c_int {
@@ -576,16 +574,16 @@ pub export fn sqlite3_uri_parameter(zFilename: [*c]const u8, zParam: [*c]const u
 pub export fn sqlite3_wal_checkpoint_v2(db: ?*c.sqlite3, zDb: [*c]const u8, eMode: c_int, pnLog: [*c]c_int, pnCkpt: [*c]c_int) c_int {
     return sqlite3_api.*.wal_checkpoint_v2.?(db, zDb, eMode, pnLog, pnCkpt);
 }
-pub export fn sqlite3_auto_extension(xEntryPoint: ?*const fn () callconv(.C) void) c_int {
+pub export fn sqlite3_auto_extension(xEntryPoint: ?*const fn () callconv(.c) void) c_int {
     return sqlite3_api.*.auto_extension.?(xEntryPoint);
 }
-pub export fn sqlite3_bind_blob64(pStmt: ?*c.sqlite3_stmt, i: c_int, zData: ?*const anyopaque, nData: c.sqlite3_uint64, xDel: ?*const fn (?*anyopaque) callconv(.C) void) c_int {
+pub export fn sqlite3_bind_blob64(pStmt: ?*c.sqlite3_stmt, i: c_int, zData: ?*const anyopaque, nData: c.sqlite3_uint64, xDel: ?*const fn (?*anyopaque) callconv(.c) void) c_int {
     return sqlite3_api.*.bind_blob64.?(pStmt, i, zData, nData, xDel);
 }
-pub export fn sqlite3_bind_text64(pStmt: ?*c.sqlite3_stmt, i: c_int, zData: [*c]const u8, nData: c.sqlite3_uint64, xDel: ?*const fn (?*anyopaque) callconv(.C) void, encoding: u8) c_int {
+pub export fn sqlite3_bind_text64(pStmt: ?*c.sqlite3_stmt, i: c_int, zData: [*c]const u8, nData: c.sqlite3_uint64, xDel: ?*const fn (?*anyopaque) callconv(.c) void, encoding: u8) c_int {
     return sqlite3_api.*.bind_text64.?(pStmt, i, zData, nData, xDel, encoding);
 }
-pub export fn sqlite3_cancel_auto_extension(xEntryPoint: ?*const fn () callconv(.C) void) c_int {
+pub export fn sqlite3_cancel_auto_extension(xEntryPoint: ?*const fn () callconv(.c) void) c_int {
     return sqlite3_api.*.cancel_auto_extension.?(xEntryPoint);
 }
 pub export fn sqlite3_load_extension(db: ?*c.sqlite3, zFile: [*c]const u8, zProc: [*c]const u8, pzErrMsg: [*c][*c]u8) c_int {
@@ -603,10 +601,10 @@ pub export fn sqlite3_realloc64(pOld: ?*anyopaque, n: c.sqlite3_uint64) ?*anyopa
 pub export fn sqlite3_reset_auto_extension() void {
     return sqlite3_api.*.reset_auto_extension.?();
 }
-pub export fn sqlite3_result_blob64(pCtx: ?*c.sqlite3_context, z: ?*const anyopaque, n: c.sqlite3_uint64, xDel: ?*const fn (?*anyopaque) callconv(.C) void) void {
+pub export fn sqlite3_result_blob64(pCtx: ?*c.sqlite3_context, z: ?*const anyopaque, n: c.sqlite3_uint64, xDel: ?*const fn (?*anyopaque) callconv(.c) void) void {
     return sqlite3_api.*.result_blob64.?(pCtx, z, n, xDel);
 }
-pub export fn sqlite3_result_text64(pCtx: ?*c.sqlite3_context, z: [*c]const u8, n: c.sqlite3_uint64, xDel: ?*const fn (?*anyopaque) callconv(.C) void, encoding: u8) void {
+pub export fn sqlite3_result_text64(pCtx: ?*c.sqlite3_context, z: [*c]const u8, n: c.sqlite3_uint64, xDel: ?*const fn (?*anyopaque) callconv(.c) void, encoding: u8) void {
     return sqlite3_api.*.result_text64.?(pCtx, z, n, xDel, encoding);
 }
 pub export fn sqlite3_strglob(zGlob: [*c]const u8, zStr: [*c]const u8) c_int {
@@ -642,7 +640,7 @@ pub export fn sqlite3_db_cacheflush(db: ?*c.sqlite3) c_int {
 pub export fn sqlite3_system_errno(db: ?*c.sqlite3) c_int {
     return sqlite3_api.*.system_errno.?(db);
 }
-pub export fn sqlite3_trace_v2(db: ?*c.sqlite3, uMask: c_uint, xCallback: ?*const fn (c_uint, ?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.C) c_int, pCtx: ?*anyopaque) c_int {
+pub export fn sqlite3_trace_v2(db: ?*c.sqlite3, uMask: c_uint, xCallback: ?*const fn (c_uint, ?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.c) c_int, pCtx: ?*anyopaque) c_int {
     return sqlite3_api.*.trace_v2.?(db, uMask, xCallback, pCtx);
 }
 pub export fn sqlite3_expanded_sql(pStmt: ?*c.sqlite3_stmt) [*c]u8 {
@@ -657,10 +655,10 @@ pub export fn sqlite3_prepare_v3(db: ?*c.sqlite3, zSql: [*c]const u8, nByte: c_i
 pub export fn sqlite3_prepare16_v3(db: ?*c.sqlite3, zSql: ?*const anyopaque, nByte: c_int, prepFlags: c_uint, ppStmt: [*c]?*c.sqlite3_stmt, pzTail: [*c]?*const anyopaque) c_int {
     return sqlite3_api.*.prepare16_v3.?(db, zSql, nByte, prepFlags, ppStmt, pzTail);
 }
-pub export fn sqlite3_bind_pointer(pStmt: ?*c.sqlite3_stmt, i: c_int, pPtr: ?*anyopaque, zPTtype: [*c]const u8, xDestructor: ?*const fn (?*anyopaque) callconv(.C) void) c_int {
+pub export fn sqlite3_bind_pointer(pStmt: ?*c.sqlite3_stmt, i: c_int, pPtr: ?*anyopaque, zPTtype: [*c]const u8, xDestructor: ?*const fn (?*anyopaque) callconv(.c) void) c_int {
     return sqlite3_api.*.bind_pointer.?(pStmt, i, pPtr, zPTtype, xDestructor);
 }
-pub export fn sqlite3_result_pointer(pCtx: ?*c.sqlite3_context, pPtr: ?*anyopaque, zPType: [*c]const u8, xDestructor: ?*const fn (?*anyopaque) callconv(.C) void) void {
+pub export fn sqlite3_result_pointer(pCtx: ?*c.sqlite3_context, pPtr: ?*anyopaque, zPType: [*c]const u8, xDestructor: ?*const fn (?*anyopaque) callconv(.c) void) void {
     return sqlite3_api.*.result_pointer.?(pCtx, pPtr, zPType, xDestructor);
 }
 pub export fn sqlite3_value_pointer(pVal: ?*c.sqlite3_value, zPType: [*c]const u8) ?*anyopaque {
@@ -717,11 +715,11 @@ pub export fn sqlite3_create_window_function(
     nArg: c_int,
     eTextRep: c_int,
     pArg: ?*anyopaque,
-    xStep: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.C) void,
-    xFinal: ?*const fn (?*c.sqlite3_context) callconv(.C) void,
-    xValue: ?*const fn (?*c.sqlite3_context) callconv(.C) void,
-    xInverse: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.C) void,
-    xDestroy: ?*const fn (?*anyopaque) callconv(.C) void,
+    xStep: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.c) void,
+    xFinal: ?*const fn (?*c.sqlite3_context) callconv(.c) void,
+    xValue: ?*const fn (?*c.sqlite3_context) callconv(.c) void,
+    xInverse: ?*const fn (?*c.sqlite3_context, c_int, [*c]?*c.sqlite3_value) callconv(.c) void,
+    xDestroy: ?*const fn (?*anyopaque) callconv(.c) void,
 ) c_int {
     return sqlite3_api.*.create_window_function.?(
         db,
@@ -778,7 +776,7 @@ pub export fn sqlite3_changes64(db: ?*c.sqlite3) c.sqlite3_int64 {
 pub export fn sqlite3_total_changes64(db: ?*c.sqlite3) c.sqlite3_int64 {
     return sqlite3_api.*.total_changes64.?(db);
 }
-pub export fn sqlite3_autovacuum_pages(db: ?*c.sqlite3, xCallback: ?*const fn (?*anyopaque, [*c]const u8, c_uint, c_uint, c_uint) callconv(.C) c_uint, pArg: ?*anyopaque, xDestructor: ?*const fn (?*anyopaque) callconv(.C) void) c_int {
+pub export fn sqlite3_autovacuum_pages(db: ?*c.sqlite3, xCallback: ?*const fn (?*anyopaque, [*c]const u8, c_uint, c_uint, c_uint) callconv(.c) c_uint, pArg: ?*anyopaque, xDestructor: ?*const fn (?*anyopaque) callconv(.c) void) c_int {
     return sqlite3_api.*.autovacuum_pages.?(db, xCallback, pArg, xDestructor);
 }
 pub export fn sqlite3_error_offset(db: ?*c.sqlite3) c_int {

--- a/errors.zig
+++ b/errors.zig
@@ -276,10 +276,7 @@ pub const DetailedError = struct {
     near: i32,
     message: []const u8,
 
-    pub fn format(self: @This(), comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt;
-        _ = options;
-
+    pub fn format(self: @This(), writer: anytype) !void {
         _ = try writer.print("{{code: {}, near: {d}, message: {s}}}", .{ self.code, self.near, self.message });
     }
 };

--- a/examples/zigcrypto.zig
+++ b/examples/zigcrypto.zig
@@ -39,7 +39,7 @@ fn createAllFunctions(db: *sqlite.Db) !void {
     );
 }
 
-pub export fn sqlite3_zigcrypto_init(raw_db: *c.sqlite3, err_msg: [*c][*c]u8, api: *c.sqlite3_api_routines) callconv(.C) c_int {
+pub export fn sqlite3_zigcrypto_init(raw_db: *c.sqlite3, err_msg: [*c][*c]u8, api: *c.sqlite3_api_routines) callconv(.c) c_int {
     _ = err_msg;
 
     c.sqlite3_api = api;

--- a/examples/zigcrypto_test.zig
+++ b/examples/zigcrypto_test.zig
@@ -41,14 +41,14 @@ pub fn main() anyerror!void {
     var diags = sqlite.Diagnostics{};
 
     const blake3_digest = db.oneAlloc([]const u8, allocator, "SELECT hex(blake3('foobar'))", .{ .diags = &diags }, .{}) catch |err| {
-        debug.print("unable to get blake3 hash, err: {!}, diags: {s}\n", .{ err, diags });
+        debug.print("unable to get blake3 hash, err: {}, diags: {f}\n", .{ err, diags });
         return err;
     };
     debug.assert(blake3_digest != null);
     debug.assert(mem.eql(u8, "AA51DCD43D5C6C5203EE16906FD6B35DB298B9B2E1DE3FCE81811D4806B76B7D", blake3_digest.?));
 
     const sha3_digest = db.oneAlloc([]const u8, allocator, "SELECT hex(sha3_512('foobar'))", .{ .diags = &diags }, .{}) catch |err| {
-        debug.print("unable to get sha3 hash, err: {!}, diags: {s}\n", .{ err, diags });
+        debug.print("unable to get sha3 hash, err: {}, diags: {f}\n", .{ err, diags });
         return err;
     };
     debug.assert(sha3_digest != null);


### PR DESCRIPTION
zig 0.15 remove usingnamespac, so tha whole loadable_extension mechanism has to be reworked, and I think its too much of a change for now, everything else is just api change in standard librark and should work just fine.

```bash
> zig version
0.15.0-dev.1222+5fb36d260
```

`zig build` works fine and I am able to use it in my project.


