### PR TITLE
Update dynamic statement all to use 0.15.1 arraylist correctly

### DIFF
--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1969,7 +1969,7 @@ pub const DynamicStatement = struct {
 
         var rows: std.ArrayList(Type) = .{};
         while (try iter.nextAlloc(allocator, options)) |row| {
-            try rows.append(row);
+            try rows.append(allocator, row);
         }
 
         return rows.toOwnedSlice();

--- a/sqlite.zig
+++ b/sqlite.zig
@@ -1972,7 +1972,7 @@ pub const DynamicStatement = struct {
             try rows.append(allocator, row);
         }
 
-        return rows.toOwnedSlice();
+        return rows.toOwnedSlice(allocator);
     }
 };
 


### PR DESCRIPTION
# Description

The dynamic statement all function was calling arraylist member functions like it was 0.14 so I added the allocator arg to the two calls which required it. I didn't open an issue so this doesn't close one but maybe it would be good to have one to track against this?

Thanks for this library.