### PR TITLE
Added option for setting SQLITE_THREADSAFE

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -169,6 +169,13 @@ pub fn build(b: *std.Build) !void {
             try flags.append(b.allocator, flag);
         }
     }
+    switch (b.option(u2, "threadsafe", "Set SQLITE_THREADSAFE to 0, 1, or 2") orelse 3) {
+        0, 1, 2 => |n| {
+            const flag = try std.fmt.allocPrint(b.allocator, "-DSQLITE_THREADSAFE={d}", .{n});
+            try flags.append(b.allocator, flag);
+        },
+        else => {},
+    }
 
     const c_flags = flags.items;
 


### PR DESCRIPTION
This PR adds an option for define setting SQLITE_THREADSAFE. It's mainly intended for compiling SQLite for WebAssembly, where thread-safety defaults to off.