### PR TITLE
sets linkage to static

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -117,7 +117,7 @@ fn makeSQLiteLib(b: *std.Build, dep: *std.Build.Dependency, c_flags: []const []c
     });
     const lib = b.addLibrary(.{
         .name = "sqlite",
-        .linkage = .dynamic,
+        .linkage = .static,
         .root_module = mod,
     });
 


### PR DESCRIPTION
Hi,

If I understand correctly, then the linking was switched by mistake from dynamic to static and then switched back to static on the main branch, but not on 0.15.1, according to the discussion in: 

https://github.com/vrischmann/zig-sqlite/issues/195 

Take care,
Martin
